### PR TITLE
Fixing REST endpoints for retrieving blogposts by userId

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A Spring Boot service that helps create, manage, validate and moderate content. 
 | POST | `/api/users` | Create new user |
 | PUT | `/api/users/{id}` | Update existing user |
 | DELETE | `/api/users/{id}` | Delete user |
+| GET | `/api/users/{id}/blogposts` | Retrieve blog posts owned by a specific user |
 
 **User Model:**
 ```json
@@ -72,7 +73,9 @@ A Spring Boot service that helps create, manage, validate and moderate content. 
 | POST | `/api/blog-posts` | Create new blog post |
 | PUT | `/api/blog-posts/{id}` | Update existing blog post |
 | DELETE | `/api/blog-posts/{id}` | Delete blog post |
-| GET | `/api/blogposts/user/{userId}` | Get all blog posts for a specific user |
+| GET | `/api/blogposts?userId={userId}` | Filter blog posts by user (optional query parameter) |
+
+> **Note:** The endpoint `/api/blogposts/user/{userId}` is now deprecated. Use `/api/blogposts?userId={userId}` instead.
 
 **Blog Post Model:**
 ```json

--- a/src/main/java/com/dehold/contentmanager/content/blogpost/service/BlogPostService.java
+++ b/src/main/java/com/dehold/contentmanager/content/blogpost/service/BlogPostService.java
@@ -53,7 +53,7 @@ public class BlogPostService {
         blogPostRepository.deleteBlogPost(id);
     }
 
-    public List<BlogPost> getBlogPostsByUser(UUID userId) {
+    public List<BlogPost> getBlogPostsByUserId(UUID userId) {
         return blogPostRepository.getBlogPostsByUserId(userId);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/content/blogpost/web/BlogPostController.java
+++ b/src/main/java/com/dehold/contentmanager/content/blogpost/web/BlogPostController.java
@@ -36,7 +36,7 @@ public class BlogPostController {
 
     @GetMapping
     public ResponseEntity<List<BlogPost>> getBlogPosts(@RequestParam(required = false) UUID userId) {
-        List<BlogPost> blogPosts = userId == null ? blogPostService.getAllBlogPosts() : blogPostService.getBlogPostsByUser(userId);
+        List<BlogPost> blogPosts = userId == null ? blogPostService.getAllBlogPosts() : blogPostService.getBlogPostsByUserId(userId);
         return ResponseEntity.ok(blogPosts);
     }
 

--- a/src/main/java/com/dehold/contentmanager/content/blogpost/web/BlogPostController.java
+++ b/src/main/java/com/dehold/contentmanager/content/blogpost/web/BlogPostController.java
@@ -35,8 +35,8 @@ public class BlogPostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<BlogPost>> getAllBlogPosts() {
-        List<BlogPost> blogPosts = blogPostService.getAllBlogPosts();
+    public ResponseEntity<List<BlogPost>> getBlogPosts(@RequestParam(required = false) UUID userId) {
+        List<BlogPost> blogPosts = userId == null ? blogPostService.getAllBlogPosts() : blogPostService.getBlogPostsByUser(userId);
         return ResponseEntity.ok(blogPosts);
     }
 
@@ -50,11 +50,5 @@ public class BlogPostController {
     public ResponseEntity<Void> deleteBlogPost(@PathVariable UUID id) {
         blogPostService.deleteBlogPost(id);
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<List<BlogPost>> getBlogPostsByUser(@PathVariable UUID userId) {
-        List<BlogPost> blogPosts = blogPostService.getBlogPostsByUser(userId);
-        return ResponseEntity.ok(blogPosts);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/user/web/UserController.java
+++ b/src/main/java/com/dehold/contentmanager/user/web/UserController.java
@@ -1,5 +1,7 @@
 package com.dehold.contentmanager.user.web;
 
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.content.blogpost.service.BlogPostService;
 import com.dehold.contentmanager.user.service.UserService;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UserResponse;
@@ -9,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -17,9 +20,11 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
+    private final BlogPostService blogPostService;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, BlogPostService blogPostService){
         this.userService = userService;
+        this.blogPostService = blogPostService;
     }
 
     @PostMapping
@@ -46,6 +51,12 @@ public class UserController {
                 user.getUpdatedAt()
         );
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}/blogposts")
+    public ResponseEntity<List<BlogPost>> getBlogpostsByUserId(@PathVariable UUID id) {
+        List<BlogPost> blogPosts = this.blogPostService.getBlogPostsByUser(id);
+        return ResponseEntity.ok(blogPosts);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/dehold/contentmanager/user/web/UserController.java
+++ b/src/main/java/com/dehold/contentmanager/user/web/UserController.java
@@ -55,7 +55,7 @@ public class UserController {
 
     @GetMapping("/{id}/blogposts")
     public ResponseEntity<List<BlogPost>> getBlogpostsByUserId(@PathVariable UUID id) {
-        List<BlogPost> blogPosts = this.blogPostService.getBlogPostsByUser(id);
+        List<BlogPost> blogPosts = this.blogPostService.getBlogPostsByUserId(id);
         return ResponseEntity.ok(blogPosts);
     }
 

--- a/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
+++ b/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
@@ -12,9 +12,9 @@ post {
 
 body:json {
   {
-    "title": "My Second Blog Post",
-    "content": "This is the content of my second blog post.",
-    "userId": "bb8bdcde-b5e4-48e3-a9ec-c724ebe30781"
+    "title": "My First Blog Post",
+    "content": "This is the content of my first blog post.",
+    "userId": "f6ababfa-5aab-4086-b218-4a394f3efbd5"
   }
 }
 

--- a/src/main/resources/content-manager-requests/users/users-blogposts.bru
+++ b/src/main/resources/content-manager-requests/users/users-blogposts.bru
@@ -1,0 +1,19 @@
+meta {
+  name: users-blogposts
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/users/:id/blogposts
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: 
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/test/java/com/dehold/contentmanager/content/blogpost/service/BlogPostServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/blogpost/service/BlogPostServiceTest.java
@@ -2,7 +2,6 @@ package com.dehold.contentmanager.content.blogpost.service;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.content.blogpost.repository.BlogPostRepository;
-import com.dehold.contentmanager.content.blogpost.service.BlogPostService;
 import com.dehold.contentmanager.content.blogpost.web.dto.CreateBlogPostRequest;
 import com.dehold.contentmanager.content.blogpost.web.dto.UpdateBlogPostRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,6 +65,27 @@ class BlogPostServiceTest {
         assertNotNull(foundBlogPost);
         assertEquals(blogPostId, foundBlogPost.getId());
         verify(blogPostRepository, times(1)).getBlogPost(blogPostId);
+    }
+
+    @Test
+    void getBlogPostsByUserId_shouldReturnBlogPostsOfUserId() {
+        UUID userId = UUID.randomUUID();
+        BlogPost blogPost1 = new BlogPost(UUID.randomUUID(), "Blog Post 1", "Content 1", Instant.now(),
+                Instant.now(), userId);
+        BlogPost blogPost2 = new BlogPost(UUID.randomUUID(), "Blog Post 2", "Content 2", Instant.now(),
+                Instant.now(), userId);
+
+        when(blogPostRepository.getBlogPostsByUserId(userId)).thenReturn(
+                java.util.List.of(blogPost1, blogPost2)
+        );
+
+        java.util.List<BlogPost> blogPosts = blogPostService.getBlogPostsByUserId(userId);
+
+        assertNotNull(blogPosts);
+        assertEquals(2, blogPosts.size());
+        assertEquals(userId, blogPosts.get(0).getUserId());
+        assertEquals(userId, blogPosts.get(1).getUserId());
+        verify(blogPostRepository, times(1)).getBlogPostsByUserId(userId);
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/content/blogpost/web/BlogPostControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/blogpost/web/BlogPostControllerIntegrationTest.java
@@ -133,7 +133,8 @@ class BlogPostControllerIntegrationTest {
         blogPostRepository.createBlogPost(blogPost2);
 
         // Act: Fetch blog posts for user1
-        ResponseEntity<BlogPost[]> response = restTemplate.getForEntity("http://localhost:" + port + "/api/blogposts/user/" + user1Id, BlogPost[].class);
+        ResponseEntity<BlogPost[]> response = restTemplate.getForEntity("http://localhost:" + port + "/api/blogposts" +
+                "?userId=" + user1Id, BlogPost[].class);
 
         // Assert: Verify the response
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/com/dehold/contentmanager/content/blogpost/web/BlogPostControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/blogpost/web/BlogPostControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.content.blogpost.repository.BlogPostRepository;
 import com.dehold.contentmanager.content.blogpost.web.dto.CreateBlogPostRequest;
 import com.dehold.contentmanager.content.blogpost.web.dto.UpdateBlogPostRequest;
-import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class BlogPostControllerIntegrationTest {
 
-    private static UUID user1Id = UUID.fromString("06c4f0e4-20d7-4886-841b-ebe0ca3622a5");
-    private static UUID user2Id = UUID.fromString("514b7a57-39a7-4623-9db0-3fda971bf11f");
+    private static final UUID user1Id = UUID.fromString("06c4f0e4-20d7-4886-841b-ebe0ca3622a5");
+    private static final UUID user2Id = UUID.fromString("514b7a57-39a7-4623-9db0-3fda971bf11f");
 
     @LocalServerPort
     private int port;
@@ -132,11 +130,9 @@ class BlogPostControllerIntegrationTest {
         blogPostRepository.createBlogPost(blogPost1);
         blogPostRepository.createBlogPost(blogPost2);
 
-        // Act: Fetch blog posts for user1
         ResponseEntity<BlogPost[]> response = restTemplate.getForEntity("http://localhost:" + port + "/api/blogposts" +
                 "?userId=" + user1Id, BlogPost[].class);
 
-        // Assert: Verify the response
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals(2, response.getBody().length);

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.dehold.contentmanager.user.web;
 
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.content.blogpost.repository.BlogPostRepository;
 import com.dehold.contentmanager.user.model.User;
 import com.dehold.contentmanager.user.repository.UserRepository;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
@@ -14,6 +16,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,6 +32,9 @@ class UserControllerIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private BlogPostRepository blogPostRepository;
 
     @Test
     void createUser_shouldReturnCreatedUser() {
@@ -83,5 +89,20 @@ class UserControllerIntegrationTest {
         assertEquals(404, response.getStatusCode().value());
         assertNotNull(response.getBody());
         assertTrue(response.getBody().contains("The entity User with id " + nonExistentId + " does not exist"));
+    }
+
+    @Test
+    void getBlogpostsByUserId_shouldReturnBlogposts() {
+        User user = new User(UUID.randomUUID(), "Blogpost User", "blogpostuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Test Blogpost", "This is a test blogpost.", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost);
+
+        ResponseEntity<BlogPost[]> response = restTemplate.getForEntity("http://localhost:" + port + "/api/users" +
+                "/" + user.getId() + "/blogposts", BlogPost[].class);
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().length);
+        assertEquals(blogPost.getId(), response.getBody()[0].getId());
     }
 }


### PR DESCRIPTION
Fixes #8 

This PR fixes the api endpoints for retrieving blog posts as per api-design best practices. This includes:
* The introduction of a new api endpoint `/api/users/{id}/blogposts`
* Changing the way blogposts can be filtered by replacing the endpoint `/api/blogposts/user/{userId}` with `/api/blogposts?userId=`