### PR TITLE
Generic ValidationStep and PhoneNumberForbiddenValidator

### DIFF
--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -4,26 +4,28 @@ import com.dehold.contentmanager.validation.result.ValidationError;
 import com.dehold.contentmanager.validation.result.ValidationResult;
 
 import java.util.List;
+import java.util.function.Function;
 
-public class LengthValidator implements ValidationStep {
+public class LengthValidator<T> implements ValidationStep<T> {
 
+    private final Function<T, String> getter;
+    private final String fieldName;
     private final int minLength;
     private final int maxLength;
     public static final String ERROR_CODE = "LENGTH_VALIDATION_FAILED";
     public static final String ERROR_MESSAGE_TOO_SHORT = "The Text is too short.";
     public static final String ERROR_MESSAGE_TOO_LONG = "The Text is too long.";
 
-    public LengthValidator(int minLength, int maxLength) {
+    public LengthValidator(Function<T, String> getter, String fieldName, int minLength, int maxLength) {
+        this.getter = getter;
+        this.fieldName = fieldName;
         this.minLength = minLength;
         this.maxLength = maxLength;
     }
 
     @Override
-    public ValidationResult validate(String content) {
-        return this.validate(content, minLength, maxLength);
-    }
-
-    private ValidationResult validate(String value, int minLength, int maxLength) {
+    public ValidationResult validate(T content) {
+        String value = getter.apply(content);
         if (minLength < 0 || maxLength < 0 || minLength > maxLength) {
             throw new IllegalArgumentException("Invalid min/max lengths");
         }

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -43,6 +43,7 @@ public class LengthValidator<T> implements ValidationStep<T> {
         return "The field '" + fieldName + "' is too long.";
     }
 
+    @Override
     public String getFieldName() {
         return this.fieldName;
     }

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -6,6 +6,7 @@ import com.dehold.contentmanager.validation.result.ValidationResult;
 import java.util.List;
 import java.util.function.Function;
 
+
 public class LengthValidator<T> implements ValidationStep<T> {
 
     private final Function<T, String> getter;
@@ -13,8 +14,6 @@ public class LengthValidator<T> implements ValidationStep<T> {
     private final int minLength;
     private final int maxLength;
     public static final String ERROR_CODE = "LENGTH_VALIDATION_FAILED";
-    public static final String ERROR_MESSAGE_TOO_SHORT = "The Text is too short.";
-    public static final String ERROR_MESSAGE_TOO_LONG = "The Text is too long.";
 
     public LengthValidator(Function<T, String> getter, String fieldName, int minLength, int maxLength) {
         this.getter = getter;
@@ -29,9 +28,22 @@ public class LengthValidator<T> implements ValidationStep<T> {
         if (minLength < 0 || maxLength < 0 || minLength > maxLength) {
             throw new IllegalArgumentException("Invalid min/max lengths");
         }
-        if(value.length() < minLength) return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE, ERROR_MESSAGE_TOO_SHORT)));
+        if(value.length() < minLength) return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
+                errorMessageTooShort(fieldName))));
         if(value.length() > maxLength) return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
-                ERROR_MESSAGE_TOO_LONG)));
+                errorMessageTooShort(fieldName))));
         return ValidationResult.valid();
+    }
+
+    public static String errorMessageTooShort(String fieldName) {
+        return "The field '" + fieldName + "' is too short.";
+    }
+
+    public static String errorMessageTooLong(String fieldName) {
+        return "The field '" + fieldName + "' is too long.";
+    }
+
+    public String getFieldName() {
+        return this.fieldName;
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 public class PhoneNumberForbiddenValidator<T> implements ValidationStep<T>{
     private final Function<T, String> getter;
     private final String fieldName;
-    private static final String ERROR_CODE = "PHONE_NUMBER_FORBIDDEN_VALIDATION_FAILED";
+    public static final String ERROR_CODE = "PHONE_NUMBER_FORBIDDEN_VALIDATION_FAILED";
 
     private static final String PHONE_PATTERN = ".*\\b(?:\\+?\\d[\\d\\s\\-]{7,})\\b.*";
 
@@ -28,7 +28,12 @@ public class PhoneNumberForbiddenValidator<T> implements ValidationStep<T>{
         return ValidationResult.valid();
     }
 
-    private static String errorMessagePhoneNumberForbidden(String fieldName) {
+    @Override
+    public String getFieldName() {
+        return this.fieldName;
+    }
+
+    public static String errorMessagePhoneNumberForbidden(String fieldName) {
         return "The field '" + fieldName + "' contains a phone number, which is not allowed.";
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
@@ -1,0 +1,34 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.validation.result.ValidationError;
+import com.dehold.contentmanager.validation.result.ValidationResult;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class PhoneNumberForbiddenValidator<T> implements ValidationStep<T>{
+    private final Function<T, String> getter;
+    private final String fieldName;
+    private static final String ERROR_CODE = "PHONE_NUMBER_FORBIDDEN_VALIDATION_FAILED";
+
+    private static final String PHONE_PATTERN = ".*\\b(?:\\+?\\d[\\d\\s\\-]{7,})\\b.*";
+
+    public PhoneNumberForbiddenValidator(Function<T, String> getter, String fieldName) {
+        this.getter = getter;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public ValidationResult validate(T content) {
+        String value = getter.apply(content);
+        if (value != null && value.matches(PHONE_PATTERN)) {
+            return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
+                    errorMessagePhoneNumberForbidden(fieldName))));
+        }
+        return ValidationResult.valid();
+    }
+
+    private static String errorMessagePhoneNumberForbidden(String fieldName) {
+        return "The field '" + fieldName + "' contains a phone number, which is not allowed.";
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
@@ -3,5 +3,5 @@ package com.dehold.contentmanager.validation.step;
 import com.dehold.contentmanager.validation.result.ValidationResult;
 
 public interface ValidationStep<T> {
-    ValidationResult validate(String content);
+    ValidationResult validate(T content);
 }

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
@@ -4,4 +4,6 @@ import com.dehold.contentmanager.validation.result.ValidationResult;
 
 public interface ValidationStep<T> {
     ValidationResult validate(T content);
+
+    String getFieldName();
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
@@ -30,7 +30,8 @@ class LengthValidatorTest {
         BlogPost post = new BlogPost(null, "Title", "Too Short", null, null, null);
         List<ValidationError> errors = blogPostContentLengthValidator.validate(post).getErrors();
         assertEquals(1, errors.size());
-        assertEquals(LengthValidator.ERROR_MESSAGE_TOO_SHORT, errors.getFirst().message());
+        assertEquals(LengthValidator.errorMessageTooShort(blogPostContentLengthValidator.getFieldName()),
+                errors.getFirst().message());
     }
 
     @Test
@@ -44,7 +45,8 @@ class LengthValidatorTest {
         BlogPost post = new BlogPost(null, "Title", "This is way too long", null, null, null);
         List<ValidationError> errors = blogPostContentLengthValidator.validate(post).getErrors();
         assertEquals(1, errors.size());
-        assertEquals(LengthValidator.ERROR_MESSAGE_TOO_LONG, errors.getFirst().message());
+        assertEquals(LengthValidator.errorMessageTooShort(blogPostContentLengthValidator.getFieldName()),
+                errors.getFirst().message());
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
@@ -58,17 +58,16 @@ class LengthValidatorTest {
     }
 
     @Test
-    void error_message_too_short() {
+    void error_message_too_short_contains_field_name() {
         String fieldName = "testField";
-        String expectedMessage = "The field '" + fieldName + "' is too short.";
-        assertEquals(expectedMessage, LengthValidator.errorMessageTooShort(fieldName));
+        assertTrue(LengthValidator.errorMessageTooShort(fieldName).contains(fieldName));
     }
 
     @Test
-    void error_message_too_long() {
+    void error_message_too_long_contains_field_name() {
         String fieldName = "testField";
         String expectedMessage = "The field '" + fieldName + "' is too long.";
-        assertEquals(expectedMessage, LengthValidator.errorMessageTooLong(fieldName));
+        assertTrue(LengthValidator.errorMessageTooLong(fieldName).contains(fieldName));
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
@@ -1,5 +1,6 @@
 package com.dehold.contentmanager.validation.step;
 
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.result.ValidationError;
 import org.junit.jupiter.api.Test;
 
@@ -9,41 +10,49 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class LengthValidatorTest {
 
-    private final LengthValidator validator = new LengthValidator(2, 5);
+    private final LengthValidator<BlogPost> blogPostContentLengthValidator =
+            new LengthValidator<BlogPost>(BlogPost::getContent,"content", 10,13);
 
     @Test
     void validate_withinBounds_returnsTrue() {
-        assertTrue(validator.validate("hello").isValid());
+        BlogPost post = new BlogPost(null, "Title", "Within Bounds", null, null, null);
+        assertTrue(blogPostContentLengthValidator.validate(post).isValid());
     }
 
     @Test
     void validate_tooShort_returnsFalse() {
-        assertFalse(validator.validate("a").isValid());
+        BlogPost post = new BlogPost(null, "Title", "Too Short", null, null, null);
+        assertFalse(blogPostContentLengthValidator.validate(post).isValid());
     }
 
     @Test
     void validate_tooShort_returnsErrorCodeAndErrorMessage() {
-        List<ValidationError> errors = validator.validate("a").getErrors();
+        BlogPost post = new BlogPost(null, "Title", "Too Short", null, null, null);
+        List<ValidationError> errors = blogPostContentLengthValidator.validate(post).getErrors();
         assertEquals(1, errors.size());
         assertEquals(LengthValidator.ERROR_MESSAGE_TOO_SHORT, errors.getFirst().message());
     }
 
     @Test
     void validate_tooLong_returnsFalse() {
-        assertFalse(validator.validate("abcdef").isValid());
+        BlogPost post = new BlogPost(null, "Title", "This is way too long.", null, null, null);
+        assertFalse(blogPostContentLengthValidator.validate(post).isValid());
     }
 
     @Test
     void validate_tooLong_returnsErrorCodeAndErrorMessage() {
-        List<ValidationError> errors = validator.validate("abcdef").getErrors();
+        BlogPost post = new BlogPost(null, "Title", "This is way too long", null, null, null);
+        List<ValidationError> errors = blogPostContentLengthValidator.validate(post).getErrors();
         assertEquals(1, errors.size());
         assertEquals(LengthValidator.ERROR_MESSAGE_TOO_LONG, errors.getFirst().message());
     }
 
     @Test
     void validate_minEqualsMax() {
-        assertTrue(validator.validate("ab").isValid());
-        assertFalse(validator.validate("a").isValid());
+        LengthValidator<BlogPost> blogPostContentLengthValidator =
+                new LengthValidator<BlogPost>(BlogPost::getContent,"content", 10,10);
+        BlogPost post = new BlogPost(null, "Title", "min == max", null, null, null);
+        assertTrue(blogPostContentLengthValidator.validate(post).isValid());
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
@@ -57,4 +57,18 @@ class LengthValidatorTest {
         assertTrue(blogPostContentLengthValidator.validate(post).isValid());
     }
 
+    @Test
+    void error_message_too_short() {
+        String fieldName = "testField";
+        String expectedMessage = "The field '" + fieldName + "' is too short.";
+        assertEquals(expectedMessage, LengthValidator.errorMessageTooShort(fieldName));
+    }
+
+    @Test
+    void error_message_too_long() {
+        String fieldName = "testField";
+        String expectedMessage = "The field '" + fieldName + "' is too long.";
+        assertEquals(expectedMessage, LengthValidator.errorMessageTooLong(fieldName));
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
@@ -46,9 +46,9 @@ class PhoneNumberForbiddenValidatorTest {
     }
 
     @Test
-    void error_message_phone_number_forbidden() {
-        String expectedMessage = "The field 'text' contains a phone number, which is not allowed.";
-        assertEquals(expectedMessage, PhoneNumberForbiddenValidator.errorMessagePhoneNumberForbidden("text"));
+    void error_message_phone_number_forbidden_contains_field_name() {
+        String fieldName = "text";
+        assertTrue(PhoneNumberForbiddenValidator.errorMessagePhoneNumberForbidden("text").contains(fieldName));
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
@@ -1,0 +1,54 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.content.customersupport.model.SupportRequest;
+import com.dehold.contentmanager.validation.result.ValidationError;
+import com.dehold.contentmanager.validation.result.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PhoneNumberForbiddenValidatorTest {
+
+    private final PhoneNumberForbiddenValidator<SupportRequest> validator =
+            new PhoneNumberForbiddenValidator<>(SupportRequest::getText, "text");
+
+    @Test
+    void validate_withPhoneNumber_returnsFalse() {
+        SupportRequest request = new SupportRequest();
+        request.setText("This contains a phone number: +1234567890");
+        ValidationResult result = validator.validate(request);
+        assertFalse(result.isValid());
+        List<ValidationError> errors = result.getErrors();
+        assertEquals(1, errors.size());
+        assertEquals(PhoneNumberForbiddenValidator.ERROR_CODE, errors.getFirst().code());
+        assertEquals(PhoneNumberForbiddenValidator.errorMessagePhoneNumberForbidden(validator.getFieldName()),
+                errors.getFirst().message());
+    }
+
+    @Test
+    void validate_withoutPhoneNumber_returnsTrue() {
+        SupportRequest request = new SupportRequest();
+        request.setText("This content is clean and has no phone numbers.");
+        ValidationResult result = validator.validate(request);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void validate_emptyContent_returnsTrue() {
+        SupportRequest request = new SupportRequest();
+        request.setText("");
+        ValidationResult result = validator.validate(request);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void error_message_phone_number_forbidden() {
+        String expectedMessage = "The field 'text' contains a phone number, which is not allowed.";
+        assertEquals(expectedMessage, PhoneNumberForbiddenValidator.errorMessagePhoneNumberForbidden("text"));
+    }
+
+}


### PR DESCRIPTION
Fixes #12 

This PR introcudes two changes:

**PhoneNumberForbiddenValidator**
This validator checks for phone numbers in content and results in a validation error in case a phone number is detected.

**ValidationStep** 
The ValidationStep is now more generic, allowing its implementations to validate based on content-types. For example, now a `PhoneNumberForbiddenValidator` can be created for the `BlogPost` content type and check the `content` field for phone numbers. The instantiation of a validator looks like this now for a phone number validator that validates the `text` field of a `SupportRequest`:
```
private final PhoneNumberForbiddenValidator<SupportRequest> validator =
            new PhoneNumberForbiddenValidator<>(SupportRequest::getText, "text");
```