### PR TITLE
Prepare ValidationResult for Persistence

### DIFF
--- a/src/main/java/com/dehold/contentmanager/content/Content.java
+++ b/src/main/java/com/dehold/contentmanager/content/Content.java
@@ -1,0 +1,7 @@
+package com.dehold.contentmanager.content;
+
+import java.util.UUID;
+
+public interface Content {
+    UUID getId();
+}

--- a/src/main/java/com/dehold/contentmanager/content/blogpost/model/BlogPost.java
+++ b/src/main/java/com/dehold/contentmanager/content/blogpost/model/BlogPost.java
@@ -25,7 +25,7 @@ public class BlogPost implements Content {
 
     @Override
     public UUID getId() {
-        return null;
+        return id;
     }
 
     public void setId(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/content/blogpost/model/BlogPost.java
+++ b/src/main/java/com/dehold/contentmanager/content/blogpost/model/BlogPost.java
@@ -1,9 +1,11 @@
 package com.dehold.contentmanager.content.blogpost.model;
 
+import com.dehold.contentmanager.content.Content;
+
 import java.time.Instant;
 import java.util.UUID;
 
-public class BlogPost {
+public class BlogPost implements Content {
 
     private UUID id;
     private String title;
@@ -21,8 +23,9 @@ public class BlogPost {
         this.userId = userId;
     }
 
+    @Override
     public UUID getId() {
-        return id;
+        return null;
     }
 
     public void setId(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportRequest.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportRequest.java
@@ -1,9 +1,11 @@
 package com.dehold.contentmanager.content.customersupport.model;
 
+import com.dehold.contentmanager.content.Content;
+
 import java.time.Instant;
 import java.util.UUID;
 
-public class SupportRequest {
+public class SupportRequest implements Content {
     private UUID id;
     private String text;
     private UUID supportResponse;
@@ -22,6 +24,7 @@ public class SupportRequest {
         this.updatedAt = updatedAt;
     }
 
+    @Override
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportResponse.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportResponse.java
@@ -1,9 +1,11 @@
 package com.dehold.contentmanager.content.customersupport.model;
 
+import com.dehold.contentmanager.content.Content;
+
 import java.time.Instant;
 import java.util.UUID;
 
-public class SupportResponse {
+public class SupportResponse implements Content {
     private UUID id;
     private String text;
     private UUID supportRequest;
@@ -20,6 +22,7 @@ public class SupportResponse {
         this.updatedAt = updatedAt;
     }
 
+    @Override
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationError.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationError.java
@@ -1,3 +1,3 @@
-package com.dehold.contentmanager.validation.result;
+package com.dehold.contentmanager.validation.model;
 
 public record ValidationError(String code, String message) {}

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
@@ -21,7 +21,7 @@ public class ValidationResult {
     }
 
     public static ValidationResult invalid(String contentType, UUID contentId, List<ValidationError> errors) {
-        return new ValidationResult(null, null, false, errors);
+        return new ValidationResult(contentType, contentId, false, errors);
     }
 
     public boolean isValid() {

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
@@ -1,7 +1,6 @@
-package com.dehold.contentmanager.validation.result;
+package com.dehold.contentmanager.validation.model;
 
 import java.util.List;
-import java.util.Objects;
 
 public class ValidationResult {
     private final boolean isValid;

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
@@ -1,22 +1,31 @@
 package com.dehold.contentmanager.validation.model;
 
 import java.util.List;
+import java.util.UUID;
 
 public class ValidationResult {
+    private final String contentType;
+    private final UUID contentId;
     private final boolean isValid;
     private final List<ValidationError> errors;
 
-    private ValidationResult(boolean isValid, List<ValidationError> errors) {
+    private ValidationResult(String contentType, UUID contentId, boolean isValid, List<ValidationError> errors) {
+        this.contentType = contentType;
+        this.contentId = contentId;
         this.isValid = isValid;
         this.errors = errors;
     }
 
     public static ValidationResult valid() {
-        return new ValidationResult(true, List.of());
+        return valid("", null);
+    }
+
+    public static ValidationResult valid(String contentType, UUID contentId) {
+        return new ValidationResult(contentType, contentId, true, List.of());
     }
 
     public static ValidationResult invalid(List<ValidationError> errors) {
-        return new ValidationResult(false, errors);
+        return new ValidationResult(null, null, false, errors);
     }
 
     public boolean isValid() {

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
@@ -16,15 +16,11 @@ public class ValidationResult {
         this.errors = errors;
     }
 
-    public static ValidationResult valid() {
-        return valid("", null);
-    }
-
     public static ValidationResult valid(String contentType, UUID contentId) {
         return new ValidationResult(contentType, contentId, true, List.of());
     }
 
-    public static ValidationResult invalid(List<ValidationError> errors) {
+    public static ValidationResult invalid(String contentType, UUID contentId, List<ValidationError> errors) {
         return new ValidationResult(null, null, false, errors);
     }
 
@@ -36,4 +32,11 @@ public class ValidationResult {
         return errors;
     }
 
+    public String getContentType() {
+        return contentType;
+    }
+
+    public UUID getContentId() {
+        return contentId;
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipeline.java
+++ b/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipeline.java
@@ -1,9 +1,6 @@
 package com.dehold.contentmanager.validation.pipeline;
 
-import com.dehold.contentmanager.validation.result.ValidationResult;
-import com.dehold.contentmanager.validation.step.ValidationStep;
-
-import java.util.List;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 
 public interface ValidationPipeline<T> {
     ValidationResult run(T content);

--- a/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineBuilder.java
+++ b/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineBuilder.java
@@ -1,11 +1,12 @@
 package com.dehold.contentmanager.validation.pipeline;
 
+import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.step.ValidationStep;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class ValidationPipelineBuilder<T> {
+public final class ValidationPipelineBuilder<T extends Content> {
     List<ValidationStep<T>> steps = new ArrayList<>();
     public ValidationPipelineBuilder<T> addStep(ValidationStep<T> step) {
         steps.add(step);

--- a/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
@@ -1,5 +1,6 @@
 package com.dehold.contentmanager.validation.pipeline;
 
+import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.step.ValidationStep;
@@ -7,7 +8,7 @@ import com.dehold.contentmanager.validation.step.ValidationStep;
 import java.util.ArrayList;
 import java.util.List;
 
-final class ValidationPipelineImpl<T> implements ValidationPipeline<T> {
+final class ValidationPipelineImpl<T extends Content> implements ValidationPipeline<T> {
     private final List<ValidationStep<T>> validationSteps;
 
     public ValidationPipelineImpl(List<ValidationStep<T>> validationSteps) {
@@ -23,6 +24,9 @@ final class ValidationPipelineImpl<T> implements ValidationPipeline<T> {
                 validationErrors.addAll(result.getErrors());
             }
         }
-        return validationErrors.isEmpty() ? ValidationResult.valid() : ValidationResult.invalid(validationErrors);
+        return validationErrors.isEmpty() ? ValidationResult.valid(content.getClass().getSimpleName(),
+                content.getId()) :
+                ValidationResult.invalid(content.getClass().getSimpleName(),
+                        content.getId(), validationErrors);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.pipeline;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.step.ValidationStep;
 
 import java.util.ArrayList;

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -3,7 +3,7 @@ package com.dehold.contentmanager.validation.service;
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipeline;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipelineBuilder;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.step;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -1,5 +1,6 @@
 package com.dehold.contentmanager.validation.step;
 
+import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 
@@ -7,7 +8,7 @@ import java.util.List;
 import java.util.function.Function;
 
 
-public class LengthValidator<T> implements ValidationStep<T> {
+public class LengthValidator<T extends Content> implements ValidationStep<T> {
 
     private final Function<T, String> getter;
     private final String fieldName;
@@ -28,11 +29,15 @@ public class LengthValidator<T> implements ValidationStep<T> {
         if (minLength < 0 || maxLength < 0 || minLength > maxLength) {
             throw new IllegalArgumentException("Invalid min/max lengths");
         }
-        if(value.length() < minLength) return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
+        if(value.length() < minLength) return ValidationResult.invalid(content.getClass().getSimpleName(),
+                content.getId(),
+                List.of(new ValidationError(ERROR_CODE,
                 errorMessageTooShort(fieldName))));
-        if(value.length() > maxLength) return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
+        if(value.length() > maxLength) return ValidationResult.invalid(content.getClass().getSimpleName(),
+                content.getId(),List.of(new ValidationError(ERROR_CODE,
                 errorMessageTooShort(fieldName))));
-        return ValidationResult.valid();
+        return ValidationResult.valid(content.getClass().getSimpleName(),
+                content.getId());
     }
 
     public static String errorMessageTooShort(String fieldName) {

--- a/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.step;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
@@ -1,12 +1,13 @@
 package com.dehold.contentmanager.validation.step;
 
+import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 
 import java.util.List;
 import java.util.function.Function;
 
-public class PhoneNumberForbiddenValidator<T> implements ValidationStep<T>{
+public class PhoneNumberForbiddenValidator<T extends Content> implements ValidationStep<T>{
     private final Function<T, String> getter;
     private final String fieldName;
     public static final String ERROR_CODE = "PHONE_NUMBER_FORBIDDEN_VALIDATION_FAILED";
@@ -22,10 +23,12 @@ public class PhoneNumberForbiddenValidator<T> implements ValidationStep<T>{
     public ValidationResult validate(T content) {
         String value = getter.apply(content);
         if (value != null && value.matches(PHONE_PATTERN)) {
-            return ValidationResult.invalid(List.of(new ValidationError(ERROR_CODE,
+            return ValidationResult.invalid(content.getClass().getSimpleName(),
+                    content.getId(),List.of(new ValidationError(ERROR_CODE,
                     errorMessagePhoneNumberForbidden(fieldName))));
         }
-        return ValidationResult.valid();
+        return ValidationResult.valid(content.getClass().getSimpleName(),
+                content.getId());
     }
 
     @Override

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStep.java
@@ -1,6 +1,6 @@
 package com.dehold.contentmanager.validation.step;
 
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 
 public interface ValidationStep<T> {
     ValidationResult validate(T content);

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.web.dto;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
@@ -5,25 +5,33 @@ import com.dehold.contentmanager.validation.model.ValidationResult;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 public class ValidationResultDto {
+    private String contentType;
+    private UUID contentId;
     private boolean valid;
     private List<ValidationError> errors;
 
     public ValidationResultDto() {
     }
 
-    public ValidationResultDto(boolean valid, List<ValidationError> errors) {
+    public ValidationResultDto(String contentType, UUID contentId, boolean valid, List<ValidationError> errors) {
+        this.contentType = contentType;
+        this.contentId = contentId;
         this.valid = valid;
         this.errors = errors;
     }
 
     public static ValidationResultDto from(ValidationResult validationResult) {
-        return new ValidationResultDto(validationResult.isValid(), validationResult.getErrors());
+        return new ValidationResultDto(validationResult.getContentType(),
+                validationResult.getContentId(), validationResult.isValid(),
+                validationResult.getErrors());
     }
 
     public ValidationResult toValidationResult() {
-        return valid ? ValidationResult.valid() : ValidationResult.invalid(errors);
+        return valid ? ValidationResult.valid(this.contentType, this.contentId) :
+                ValidationResult.invalid(this.contentType, this.contentId, errors);
     }
 
     public boolean isValid() {

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
@@ -50,6 +50,14 @@ public class ValidationResultDto {
         this.errors = errors;
     }
 
+    public String getContentType() {
+        return contentType;
+    }
+
+    public UUID getContentId() {
+        return contentId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/resources/content-manager-requests/validate/validate-blog-post (FAIL).bru
+++ b/src/main/resources/content-manager-requests/validate/validate-blog-post (FAIL).bru
@@ -17,6 +17,7 @@ body:json {
     "contentMinLength": 10,
     "contentMaxLength": 2000,
     "blogPost": {
+      "id": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f",
       "title": "Short",
       "content": "This content is fine but the title is too short."
     }

--- a/src/main/resources/content-manager-requests/validate/validate-blog-post.bru
+++ b/src/main/resources/content-manager-requests/validate/validate-blog-post.bru
@@ -17,6 +17,7 @@ body:json {
     "contentMinLength": 10,
     "contentMaxLength": 2000,
     "blogPost": {
+      "id": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f",
       "title": "A Valid Blog Post Title",
       "content": "This content is long enough to meet the minimum content length requirement."
     }

--- a/src/test/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineTest.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.pipeline;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.step.PhoneNumberForbiddenValidator;
 import com.dehold.contentmanager.validation.step.ValidationStep;

--- a/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/LengthValidatorTest.java
@@ -1,7 +1,7 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
-import com.dehold.contentmanager.validation.result.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidatorTest.java
@@ -1,8 +1,8 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.customersupport.model.SupportRequest;
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -117,4 +117,23 @@ class ValidationControllerIntegrationTest {
         assertNotNull(actual);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void whenValidate_thenResponseContainsValidationResultIncludingContentTypeAndContentId() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Valid Title", "This is valid content for the blog post."
+                , Instant.now(), Instant.now(), UUID.randomUUID());
+        BlogPostValidationRequest request = new BlogPostValidationRequest(3, 100, 10, 1000, blogPost);
+
+        var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/blogpost", request,
+                ValidationResponse.class);
+
+        assertEquals(200, response.getStatusCode().value());
+        ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
+        ValidationResponse actual = response.getBody();
+        assertNotNull(actual);
+        assertEquals(expected.getValidationResult().getContentType(), actual.getValidationResult().getContentType());
+        assertEquals(expected.getValidationResult().getContentId(), actual.getValidationResult().getContentId());
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -2,8 +2,8 @@ package com.dehold.contentmanager.validation.web;
 
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
-import com.dehold.contentmanager.validation.result.ValidationError;
-import com.dehold.contentmanager.validation.result.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -41,7 +41,7 @@ class ValidationControllerIntegrationTest {
 
         assertEquals(200, response.getStatusCode().value());
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.valid()));
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getContentType(), actual.getContentType());
@@ -64,7 +64,7 @@ class ValidationControllerIntegrationTest {
                 new ValidationError(LengthValidator.ERROR_CODE,
                         LengthValidator.errorMessageTooShort("title")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.invalid(validationErrors)));
+                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(), blogPost.getId(),validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getContentType(), actual.getContentType());
@@ -87,7 +87,8 @@ class ValidationControllerIntegrationTest {
                 new ValidationError(LengthValidator.ERROR_CODE,
                         LengthValidator.errorMessageTooShort("content")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.invalid(validationErrors)));
+                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(), blogPost.getId(),
+                        validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getContentType(), actual.getContentType());
@@ -110,7 +111,8 @@ class ValidationControllerIntegrationTest {
                 new ValidationError(LengthValidator.ERROR_CODE,
                         LengthValidator.errorMessageTooShort("content")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.invalid(validationErrors)));
+                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(),
+                        blogPost.getId(), validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected, actual);

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -119,10 +119,30 @@ class ValidationControllerIntegrationTest {
     }
 
     @Test
-    void whenValidate_thenResponseContainsValidationResultIncludingContentTypeAndContentId() {
+    void givenValidContent_whenValidate_thenResponseContainsValidationResultIncludingContentTypeAndContentId() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Valid Title", "This is valid content for the blog post."
                 , Instant.now(), Instant.now(), UUID.randomUUID());
         BlogPostValidationRequest request = new BlogPostValidationRequest(3, 100, 10, 1000, blogPost);
+
+        var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/blogpost", request,
+                ValidationResponse.class);
+
+        assertEquals(200, response.getStatusCode().value());
+        ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
+        ValidationResponse actual = response.getBody();
+        assertNotNull(actual);
+        assertEquals(expected.getValidationResult().getContentType(), actual.getValidationResult().getContentType());
+        assertEquals(expected.getValidationResult().getContentId(), actual.getValidationResult().getContentId());
+    }
+
+    @Test
+    void givenInvalidContent_whenValidate_thenResponseContainsValidationResultIncludingContentTypeAndContentId() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Invalid: This title is too short", "This is valid " +
+                "content for the " +
+                "blog post."
+                , Instant.now(), Instant.now(), UUID.randomUUID());
+        BlogPostValidationRequest request = new BlogPostValidationRequest(50, 100, 10, 1000, blogPost);
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/blogpost", request,
                 ValidationResponse.class);

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
@@ -1,10 +1,13 @@
 package com.dehold.contentmanager.validation.web.dto;
 
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.content.customersupport.model.SupportRequest;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,8 +19,12 @@ class ValidationResponseTest {
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
 
-        ValidationResultDto validationResult1 = new ValidationResultDto(true, List.of(error1, error2));
-        ValidationResultDto validationResult2 = new ValidationResultDto(true, List.of(error1, error2));
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, true, List.of(error1,
+                error2));
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId,true, List.of(error1, error2));
 
         ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
         ValidationResponse response2 = new ValidationResponse("BlogPost", validationResult2);
@@ -30,8 +37,12 @@ class ValidationResponseTest {
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
 
-        ValidationResultDto validationResult1 = new ValidationResultDto(true, List.of(error1, error2));
-        ValidationResultDto validationResult2 = new ValidationResultDto(false, List.of(error1));
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, true, List.of(error1,
+                error2));
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId, false, List.of(error1));
 
         ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
         ValidationResponse response2 = new ValidationResponse("BlogPost", validationResult2);
@@ -41,10 +52,16 @@ class ValidationResponseTest {
 
     @Test
     void givenDifferentContentTypes_whenEquals_thenReturnFalse() {
-        ValidationResultDto validationResult = new ValidationResultDto(true, null);
+        String contentType1 = BlogPost.class.getSimpleName();
+        String contentType2 = SupportRequest.class.getSimpleName();
+        UUID contentId1 = UUID.randomUUID();
+        UUID contentId2 = UUID.randomUUID();
 
-        ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult);
-        ValidationResponse response2 = new ValidationResponse("Article", validationResult);
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType1, contentId1, true, null);
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType2, contentId2, true, null);
+
+        ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
+        ValidationResponse response2 = new ValidationResponse("Article", validationResult2);
 
         assertNotEquals(response1, response2);
     }

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
@@ -1,6 +1,6 @@
 package com.dehold.contentmanager.validation.web.dto;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
@@ -1,10 +1,12 @@
 package com.dehold.contentmanager.validation.web.dto;
 
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,39 +15,51 @@ class ValidationResultDtoTest {
 
     @Test
     void givenEqualValidationResultDtosWithNullError_whenEquals_thenReturnTrue() {
-        ValidationResultDto dto1 = new ValidationResultDto(true, null);
-        ValidationResultDto dto2 = new ValidationResultDto(true, null);
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, true, null);
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, true, null);
 
         assertEquals(dto1, dto2);
     }
 
     @Test
     void givenDifferentValidationResultDtosWithNullError_whenEquals_thenReturnFalse() {
-        ValidationResultDto dto1 = new ValidationResultDto(true, null);
-        ValidationResultDto dto2 = new ValidationResultDto(false, null);
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, true, null);
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, null);
 
         assertNotEquals(dto1, dto2);
     }
 
     @Test
     void givenEqualValidationResultDtosWithErrors_whenEquals_thenReturnTrue() {
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
 
-        ValidationResultDto dto1 = new ValidationResultDto(false, List.of(error1, error2));
-        ValidationResultDto dto2 = new ValidationResultDto(false, List.of(error1, error2));
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
 
         assertEquals(dto1, dto2);
     }
 
     @Test
     void givenDifferentValidationResultDtosWithErrors_whenEquals_thenReturnFalse() {
+        String contentType = BlogPost.class.getSimpleName();
+        UUID contentId = UUID.randomUUID();
+
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
         ValidationError error3 = new ValidationError("FIELD_3", "Error message 3");
 
-        ValidationResultDto dto1 = new ValidationResultDto(false, List.of(error1, error2));
-        ValidationResultDto dto2 = new ValidationResultDto(false, List.of(error1, error3));
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error3));
 
         assertNotEquals(dto1, dto2);
     }

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
@@ -1,6 +1,6 @@
 package com.dehold.contentmanager.validation.web.dto;
 
-import com.dehold.contentmanager.validation.result.ValidationError;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 


### PR DESCRIPTION
Fixes #22 

This PR introduces two new fields to the `ValidationResult`, which makes it suitable for persistence. The structure now looks like this:
```java
public class ValidationResult {
    private final String contentType;
    private final UUID contentId;
    private final boolean isValid;
    private final List<ValidationError> errors;

    private ValidationResult(String contentType, UUID contentId, boolean isValid, List<ValidationError> errors) {
        this.contentType = contentType;
        this.contentId = contentId;
        this.isValid = isValid;
        this.errors = errors;
    }
    // ... some more code
}
```

Also, the respnse of the `/api/validate/blogpost` endpoint returns the enriched version of the `ValidationResult`:

```json
{
  "contentType": "BlogPost",
  "validationResult": {
    "contentType": "BlogPost", /* -> new field */
    "contentId": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f", /* -> new field */
    "valid": false,
    "errors": [
      {
        "code": "LENGTH_VALIDATION_FAILED",
        "message": "The field 'title' is too short."
      }
    ]
  }
}
```