### PR TITLE
UserId for ValidationResult and Content Entities

### DIFF
--- a/src/main/java/com/dehold/contentmanager/content/Content.java
+++ b/src/main/java/com/dehold/contentmanager/content/Content.java
@@ -4,4 +4,6 @@ import java.util.UUID;
 
 public interface Content {
     UUID getId();
+
+    UUID getUserId();
 }

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportRequest.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportRequest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public class SupportRequest implements Content {
     private UUID id;
+    private UUID userId;
     private String text;
     private UUID supportResponse;
     private UUID customerId;
@@ -15,8 +16,10 @@ public class SupportRequest implements Content {
 
     public SupportRequest() {}
 
-    public SupportRequest(UUID id, String text, UUID supportResponse, UUID customerId, Instant createdAt, Instant updatedAt) {
+    public SupportRequest(UUID id, UUID userId, String text, UUID supportResponse, UUID customerId, Instant createdAt,
+                          Instant updatedAt) {
         this.id = id;
+        this.userId = userId;
         this.text = text;
         this.supportResponse = supportResponse;
         this.customerId = customerId;
@@ -27,6 +30,11 @@ public class SupportRequest implements Content {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public UUID getUserId() {
+        return userId;
     }
 
     public void setId(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportResponse.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/model/SupportResponse.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public class SupportResponse implements Content {
     private UUID id;
+    private UUID userId;
     private String text;
     private UUID supportRequest;
     private Instant createdAt;
@@ -14,8 +15,10 @@ public class SupportResponse implements Content {
 
     public SupportResponse() {}
 
-    public SupportResponse(UUID id, String text, UUID supportRequest, Instant createdAt, Instant updatedAt) {
+    public SupportResponse(UUID id, UUID userId, String text, UUID supportRequest, Instant createdAt,
+                           Instant updatedAt) {
         this.id = id;
+        this.userId = userId;
         this.text = text;
         this.supportRequest = supportRequest;
         this.createdAt = createdAt;
@@ -25,6 +28,11 @@ public class SupportResponse implements Content {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public UUID getUserId() {
+        return userId;
     }
 
     public void setId(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportRequestRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportRequestRepository.java
@@ -24,6 +24,7 @@ public class SupportRequestRepository {
         public SupportRequest mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new SupportRequest(
                 UUID.fromString(rs.getString("id")),
+                UUID.fromString(rs.getString("user_id")),
                 rs.getString("text"),
                 UUID.fromString(rs.getString("support_response")),
                 UUID.fromString(rs.getString("customer_id")),
@@ -34,12 +35,15 @@ public class SupportRequestRepository {
     };
 
     public void create(SupportRequest request) {
-        String sql = "INSERT INTO customer_request (id, text, support_response, customer_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)";
-        jdbcTemplate.update(sql, request.getId(), request.getText(), request.getSupportResponse(), request.getCustomerId(), request.getCreatedAt(), request.getUpdatedAt());
+        String sql = "INSERT INTO customer_request (id, userId, text, support_response, customer_id, created_at, " +
+                "updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(sql, request.getId(), request.getUserId(), request.getText(), request.getSupportResponse(),
+                request.getCustomerId(), request.getCreatedAt(), request.getUpdatedAt());
     }
 
     public void update(SupportRequest request) {
-        String sql = "UPDATE customer_request SET text = ?, support_response = ?, customer_id = ?, created_at = ?, updated_at = ? WHERE id = ?";
+        String sql = "UPDATE customer_request SET text = ?, support_response = ?, customer_id = ?, created_at = " +
+                "?, updated_at = ? WHERE id = ?";
         jdbcTemplate.update(sql, request.getText(), request.getSupportResponse(), request.getCustomerId(), request.getCreatedAt(), request.getUpdatedAt(), request.getId());
     }
 

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportRequestRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportRequestRepository.java
@@ -35,7 +35,7 @@ public class SupportRequestRepository {
     };
 
     public void create(SupportRequest request) {
-        String sql = "INSERT INTO customer_request (id, userId, text, support_response, customer_id, created_at, " +
+        String sql = "INSERT INTO customer_request (id, user_id, text, support_response, customer_id, created_at, " +
                 "updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
         jdbcTemplate.update(sql, request.getId(), request.getUserId(), request.getText(), request.getSupportResponse(),
                 request.getCustomerId(), request.getCreatedAt(), request.getUpdatedAt());

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
@@ -33,8 +33,9 @@ public class SupportResponseRepository {
     };
 
     public void create(SupportResponse response) {
-        String sql = "INSERT INTO support_response (id, userId, text, support_request, created_at, updated_at) VALUES" +
-                " (?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO support_response (id, user_id, text, support_request, created_at, updated_at) " +
+                "VALUES" +
+                " (?, ?, ?, ?, ?, ?)";
         jdbcTemplate.update(sql, response.getId(), response.getUserId(), response.getText(),
                 response.getSupportRequest(),
                 response.getCreatedAt(), response.getUpdatedAt());

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
@@ -23,6 +23,7 @@ public class SupportResponseRepository {
         public SupportResponse mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new SupportResponse(
                 UUID.fromString(rs.getString("id")),
+                UUID.fromString(rs.getString("user_id")),
                 rs.getString("text"),
                 UUID.fromString(rs.getString("support_request")),
                 rs.getTimestamp("created_at").toInstant(),
@@ -32,8 +33,11 @@ public class SupportResponseRepository {
     };
 
     public void create(SupportResponse response) {
-        String sql = "INSERT INTO support_response (id, text, support_request, created_at, updated_at) VALUES (?, ?, ?, ?, ?)";
-        jdbcTemplate.update(sql, response.getId(), response.getText(), response.getSupportRequest(), response.getCreatedAt(), response.getUpdatedAt());
+        String sql = "INSERT INTO support_response (id, userId, text, support_request, created_at, updated_at) VALUES" +
+                " (?, ?, ?, ?, ?)";
+        jdbcTemplate.update(sql, response.getId(), response.getUserId(), response.getText(),
+                response.getSupportRequest(),
+                response.getCreatedAt(), response.getUpdatedAt());
     }
 
     public Optional<SupportResponse> getById(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/web/SupportRequestController.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/web/SupportRequestController.java
@@ -38,6 +38,7 @@ public class SupportRequestController {
     public ResponseEntity<CustomerRequestDto> create(@RequestBody CustomerRequestDto dto) {
         SupportRequest entity = new SupportRequest(
                 UUID.randomUUID(),
+                UUID.randomUUID(),
                 dto.getText(),
                 dto.getSupportResponse(),
                 dto.getCustomerId(),
@@ -53,6 +54,7 @@ public class SupportRequestController {
         SupportRequest existing = service.findById(id); // This will throw EntityNotFoundException if not found
         SupportRequest entity = new SupportRequest(
                 id,
+                UUID.randomUUID(),
                 dto.getText(),
                 dto.getSupportResponse(),
                 dto.getCustomerId(),

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/web/SupportResponseController.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/web/SupportResponseController.java
@@ -22,7 +22,7 @@ public class SupportResponseController {
 
     @PostMapping
     public ResponseEntity<SupportResponse> create(@RequestBody CreateSupportResponseRequest request) {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), request.getText(), request.getSupportRequest(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), request.getText(), request.getSupportRequest(), Instant.now(), Instant.now());
         service.createSupportResponse(response);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
@@ -36,7 +36,7 @@ public class SupportResponseController {
     @PutMapping("/{id}")
     public ResponseEntity<SupportResponse> update(@PathVariable UUID id, @RequestBody UpdateSupportResponseRequest request) {
         SupportResponse supportResponse = service.getSupportResponse(id);
-        SupportResponse updated = new SupportResponse(id, request.getText(), request.getSupportRequest(), supportResponse.getCreatedAt(), Instant.now());
+        SupportResponse updated = new SupportResponse(id, UUID.randomUUID(), request.getText(), request.getSupportRequest(), supportResponse.getCreatedAt(), Instant.now());
         service.updateSupportResponse(updated);
         return ResponseEntity.ok(updated);
     }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationResult.java
@@ -6,23 +6,28 @@ import java.util.UUID;
 
 public class ValidationResult {
     private final UUID id;
+    private final UUID userId;
     private final String contentType;
     private final UUID contentId;
     private final boolean isValid;
     private final List<ValidationError> errors;
     private final Instant createdAt;
 
-    private ValidationResult(String contentType, UUID contentId, boolean isValid, List<ValidationError> errors) {
+    private ValidationResult(String contentType, UUID contentId, UUID userId, boolean isValid,
+                             List<ValidationError> errors) {
         this.contentType = contentType;
         this.contentId = contentId;
+        this.userId = userId;
         this.isValid = isValid;
         this.errors = errors;
         this.id = UUID.randomUUID();
         this.createdAt = Instant.now();
     }
 
-    private ValidationResult(UUID id, String contentType, UUID contentId, boolean isValid, List<ValidationError> errors, Instant createdAt) {
+    private ValidationResult(UUID id, UUID userId, String contentType, UUID contentId, boolean isValid,
+                             List<ValidationError> errors, Instant createdAt) {
         this.id = id;
+        this.userId = userId;
         this.contentType = contentType;
         this.contentId = contentId;
         this.isValid = isValid;
@@ -30,16 +35,18 @@ public class ValidationResult {
         this.createdAt = createdAt;
     }
 
-    public static ValidationResult valid(String contentType, UUID contentId) {
-        return new ValidationResult(contentType, contentId, true, List.of());
+    public static ValidationResult valid(String contentType, UUID contentId, UUID userId) {
+        return new ValidationResult(contentType, contentId, userId, true, List.of());
     }
 
-    public static ValidationResult invalid(String contentType, UUID contentId, List<ValidationError> errors) {
-        return new ValidationResult(contentType, contentId, false, errors);
+    public static ValidationResult invalid(String contentType, UUID contentId,
+                                           UUID userId, List<ValidationError> errors) {
+        return new ValidationResult(contentType, contentId, userId, false, errors);
     }
 
-    public static ValidationResult fromPersistence(UUID id, String contentType, UUID contentId, boolean isValid, List<ValidationError> errors, Instant createdAt) {
-        return new ValidationResult(id, contentType, contentId, isValid, errors, createdAt);
+    public static ValidationResult fromPersistence(UUID id, UUID userId, String contentType, UUID contentId,
+                                                   boolean isValid, List<ValidationError> errors, Instant createdAt) {
+        return new ValidationResult(id, userId, contentType, contentId, isValid, errors, createdAt);
     }
 
     public boolean isValid() {
@@ -60,6 +67,10 @@ public class ValidationResult {
 
     public UUID getId() {
         return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineImpl.java
@@ -25,8 +25,8 @@ final class ValidationPipelineImpl<T extends Content> implements ValidationPipel
             }
         }
         return validationErrors.isEmpty() ? ValidationResult.valid(content.getClass().getSimpleName(),
-                content.getId()) :
+                content.getId(), content.getUserId()) :
                 ValidationResult.invalid(content.getClass().getSimpleName(),
-                        content.getId(), validationErrors);
+                        content.getId(), content.getUserId(), validationErrors);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
@@ -26,8 +26,10 @@ public class ValidationResultRepository {
 
     public void create(ValidationResult validationResult) {
         jdbcTemplate.update(
-                "INSERT INTO validation_result (id, content_id, content_type, is_valid, errors, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO validation_result (id, user_id, content_id, content_type, is_valid, errors, created_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?)",
                 validationResult.getId(),
+                validationResult.getUserId(),
                 validationResult.getContentId(),
                 validationResult.getContentType(),
                 validationResult.isValid(),
@@ -43,6 +45,7 @@ public class ValidationResultRepository {
     private ValidationResult mapRowToValidationResult(ResultSet rs, int rowNum) throws SQLException {
         return ValidationResult.fromPersistence(
                 UUID.fromString(rs.getString("id")),
+                UUID.fromString(rs.getString("user_id")),
                 rs.getString("content_type"),
                 UUID.fromString(rs.getString("content_id")),
                 rs.getBoolean("is_valid"),

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
@@ -27,7 +27,7 @@ public class ValidationResultRepository {
     public void create(ValidationResult validationResult) {
         jdbcTemplate.update(
                 "INSERT INTO validation_result (id, user_id, content_id, content_type, is_valid, errors, created_at) " +
-                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 validationResult.getId(),
                 validationResult.getUserId(),
                 validationResult.getContentId(),

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -31,13 +31,14 @@ public class LengthValidator<T extends Content> implements ValidationStep<T> {
         }
         if(value.length() < minLength) return ValidationResult.invalid(content.getClass().getSimpleName(),
                 content.getId(),
+                content.getUserId(),
                 List.of(new ValidationError(ERROR_CODE,
                 errorMessageTooShort(fieldName))));
         if(value.length() > maxLength) return ValidationResult.invalid(content.getClass().getSimpleName(),
-                content.getId(),List.of(new ValidationError(ERROR_CODE,
+                content.getId(),content.getUserId(),List.of(new ValidationError(ERROR_CODE,
                 errorMessageTooShort(fieldName))));
         return ValidationResult.valid(content.getClass().getSimpleName(),
-                content.getId());
+                content.getId(), content.getUserId());
     }
 
     public static String errorMessageTooShort(String fieldName) {

--- a/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/PhoneNumberForbiddenValidator.java
@@ -24,11 +24,11 @@ public class PhoneNumberForbiddenValidator<T extends Content> implements Validat
         String value = getter.apply(content);
         if (value != null && value.matches(PHONE_PATTERN)) {
             return ValidationResult.invalid(content.getClass().getSimpleName(),
-                    content.getId(),List.of(new ValidationError(ERROR_CODE,
+                    content.getId(), content.getUserId(), List.of(new ValidationError(ERROR_CODE,
                     errorMessagePhoneNumberForbidden(fieldName))));
         }
         return ValidationResult.valid(content.getClass().getSimpleName(),
-                content.getId());
+                content.getId(), content.getUserId());
     }
 
     @Override

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDto.java
@@ -10,28 +10,31 @@ import java.util.UUID;
 public class ValidationResultDto {
     private String contentType;
     private UUID contentId;
+    private UUID userId;
     private boolean valid;
     private List<ValidationError> errors;
 
     public ValidationResultDto() {
     }
 
-    public ValidationResultDto(String contentType, UUID contentId, boolean valid, List<ValidationError> errors) {
+    public ValidationResultDto(String contentType, UUID contentId, UUID userId, boolean valid,
+                               List<ValidationError> errors) {
         this.contentType = contentType;
         this.contentId = contentId;
+        this.userId = userId;
         this.valid = valid;
         this.errors = errors;
     }
 
     public static ValidationResultDto from(ValidationResult validationResult) {
         return new ValidationResultDto(validationResult.getContentType(),
-                validationResult.getContentId(), validationResult.isValid(),
+                validationResult.getContentId(), validationResult.getUserId(), validationResult.isValid(),
                 validationResult.getErrors());
     }
 
     public ValidationResult toValidationResult() {
-        return valid ? ValidationResult.valid(this.contentType, this.contentId) :
-                ValidationResult.invalid(this.contentType, this.contentId, errors);
+        return valid ? ValidationResult.valid(this.contentType, this.contentId, this.userId) :
+                ValidationResult.invalid(this.contentType, this.contentId, this.userId, errors);
     }
 
     public boolean isValid() {
@@ -58,16 +61,21 @@ public class ValidationResultDto {
         return contentId;
     }
 
+    public UUID getUserId() {
+        return userId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ValidationResultDto that = (ValidationResultDto) o;
-        return valid == that.valid && Objects.equals(errors, that.errors);
+        return valid == that.valid && Objects.equals(userId, that.userId) && Objects.equals(contentId,
+                that.contentId) && Objects.equals(contentType, that.contentType) && Objects.equals(errors, that.errors);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(valid, errors);
+        return Objects.hash(contentType, contentId, userId, valid, errors);
     }
 }

--- a/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
+++ b/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
@@ -14,7 +14,7 @@ body:json {
   {
     "title": "My First Blog Post",
     "content": "This is the content of my first blog post.",
-    "userId": "f6ababfa-5aab-4086-b218-4a394f3efbd5"
+    "userId": "eeb9e41b-4718-471b-94d4-478bb9a9147a"
   }
 }
 

--- a/src/main/resources/content-manager-requests/blogposts/blogposts-getById.bru
+++ b/src/main/resources/content-manager-requests/blogposts/blogposts-getById.bru
@@ -11,7 +11,7 @@ get {
 }
 
 params:path {
-  id: ed62d2eb-c293-4c48-a5ce-bc1130d19610
+  id: ca17604a-b329-453c-9888-5e9132298064
 }
 
 settings {

--- a/src/main/resources/content-manager-requests/validate/validate-blog-post (FAIL).bru
+++ b/src/main/resources/content-manager-requests/validate/validate-blog-post (FAIL).bru
@@ -18,6 +18,7 @@ body:json {
     "contentMaxLength": 2000,
     "blogPost": {
       "id": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f",
+      "userId": "f6ababfa-5aab-4086-b218-4a394f3efbd5",
       "title": "Short",
       "content": "This content is fine but the title is too short."
     }

--- a/src/main/resources/content-manager-requests/validate/validate-blog-post.bru
+++ b/src/main/resources/content-manager-requests/validate/validate-blog-post.bru
@@ -18,6 +18,7 @@ body:json {
     "contentMaxLength": 2000,
     "blogPost": {
       "id": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f",
+      "userId": "f6ababfa-5aab-4086-b218-4a394f3efbd5",
       "title": "A Valid Blog Post Title",
       "content": "This content is long enough to meet the minimum content length requirement."
     }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS customer_request (
 
 CREATE TABLE IF NOT EXISTS validation_result (
     id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
     content_id UUID NOT NULL,
     content_type VARCHAR(255) NOT NULL,
     is_valid BOOLEAN NOT NULL,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS blog_post (
 
 CREATE TABLE IF NOT EXISTS support_response (
     id UUID PRIMARY KEY,
+    user_id UUID,
     text TEXT NOT NULL,
     support_request UUID NOT NULL,
     created_at TIMESTAMP NOT NULL,
@@ -26,6 +27,7 @@ CREATE TABLE IF NOT EXISTS support_response (
 
 CREATE TABLE IF NOT EXISTS customer_request (
     id UUID PRIMARY KEY,
+    user_id UUID,
     text TEXT NOT NULL,
     support_response UUID NOT NULL,
     customer_id UUID NOT NULL,

--- a/src/test/java/com/dehold/contentmanager/content/customersupport/service/SupportRequestServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/customersupport/service/SupportRequestServiceTest.java
@@ -32,6 +32,7 @@ class SupportRequestServiceTest {
     void save_shouldCallRepositoryCreate() {
         SupportRequest request = new SupportRequest(
             UUID.randomUUID(),
+            UUID.randomUUID(),
             "Test text",
             UUID.randomUUID(),
             UUID.randomUUID(),
@@ -49,6 +50,7 @@ class SupportRequestServiceTest {
         UUID id = UUID.randomUUID();
         SupportRequest request = new SupportRequest(
             id,
+            UUID.randomUUID(),
             "Test text",
             UUID.randomUUID(),
             UUID.randomUUID(),

--- a/src/test/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseServiceTest.java
@@ -29,7 +29,8 @@ class SupportResponseServiceTest {
 
     @Test
     void createSupportResponse_shouldCallRepository() {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), "Test text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), "Test text",
+                UUID.randomUUID(), Instant.now(), Instant.now());
         doNothing().when(repository).create(any(SupportResponse.class));
         service.createSupportResponse(response);
         verify(repository, times(1)).create(any(SupportResponse.class));
@@ -38,7 +39,8 @@ class SupportResponseServiceTest {
     @Test
     void getSupportResponse_shouldReturnResponseIfExists() {
         UUID id = UUID.randomUUID();
-        SupportResponse response = new SupportResponse(id, "Test text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(id, UUID.randomUUID(),"Test text", UUID.randomUUID(),
+                Instant.now(), Instant.now());
         when(repository.getById(id)).thenReturn(Optional.of(response));
         SupportResponse found = service.getSupportResponse(id);
         assertEquals(response.getId(), found.getId());
@@ -47,7 +49,8 @@ class SupportResponseServiceTest {
 
     @Test
     void updateSupportResponse_shouldCallRepository() {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), "Updated text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), "Updated text", UUID.randomUUID(),
+                Instant.now(), Instant.now());
         doNothing().when(repository).update(any(SupportResponse.class));
         service.updateSupportResponse(response);
         verify(repository, times(1)).update(any(SupportResponse.class));

--- a/src/test/java/com/dehold/contentmanager/content/customersupport/web/SupportRequestControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/customersupport/web/SupportRequestControllerIntegrationTest.java
@@ -54,6 +54,7 @@ class SupportRequestControllerIntegrationTest {
     void getCustomerRequest_shouldReturnRequest() {
         SupportRequest request = new SupportRequest(
             UUID.randomUUID(),
+            UUID.randomUUID(),
             "Test text",
             UUID.randomUUID(),
             UUID.randomUUID(),
@@ -76,6 +77,7 @@ class SupportRequestControllerIntegrationTest {
     @Test
     void updateCustomerRequest_shouldReturnUpdated() {
         SupportRequest request = new SupportRequest(
+            UUID.randomUUID(),
             UUID.randomUUID(),
             "Old text",
             UUID.randomUUID(),
@@ -107,6 +109,7 @@ class SupportRequestControllerIntegrationTest {
     @Test
     void deleteCustomerRequest_shouldReturnNoContent() {
         SupportRequest request = new SupportRequest(
+            UUID.randomUUID(),
             UUID.randomUUID(),
             "Test text",
             UUID.randomUUID(),

--- a/src/test/java/com/dehold/contentmanager/content/customersupport/web/SupportResponseControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/customersupport/web/SupportResponseControllerIntegrationTest.java
@@ -47,7 +47,7 @@ class SupportResponseControllerIntegrationTest {
 
     @Test
     void getSupportResponse_shouldReturnResponse() {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), "Test text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), "Test text", UUID.randomUUID(), Instant.now(), Instant.now());
         repository.create(response);
         ResponseEntity<SupportResponse> getResponse = restTemplate.getForEntity(
             "http://localhost:" + port + "/api/support-responses/" + response.getId(),
@@ -61,7 +61,7 @@ class SupportResponseControllerIntegrationTest {
 
     @Test
     void updateSupportResponse_shouldReturnUpdated() {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), "Old text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), "Old text", UUID.randomUUID(), Instant.now(), Instant.now());
         repository.create(response);
         UpdateSupportResponseRequest request = new UpdateSupportResponseRequest();
         request.setText("Updated text");
@@ -80,7 +80,7 @@ class SupportResponseControllerIntegrationTest {
 
     @Test
     void deleteSupportResponse_shouldDelete() {
-        SupportResponse response = new SupportResponse(UUID.randomUUID(), "Delete text", UUID.randomUUID(), Instant.now(), Instant.now());
+        SupportResponse response = new SupportResponse(UUID.randomUUID(), UUID.randomUUID(), "Delete text", UUID.randomUUID(), Instant.now(), Instant.now());
         repository.create(response);
         restTemplate.delete("http://localhost:" + port + "/api/support-responses/" + response.getId());
         ResponseEntity<SupportResponse> getResponse = restTemplate.getForEntity(

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationResultRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationResultRepositoryTest.java
@@ -35,18 +35,22 @@ class ValidationResultRepositoryTest {
     @Test
     void whenValidationResultCreateCalled_thenJdbcTemplateUpdateCalledWithProperParameters() {
         UUID id = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
         UUID contentId = UUID.randomUUID();
         String contentType = "testContentType";
         boolean isValid = true;
         Instant createdAt = Instant.now();
 
-        ValidationResult validationResult = ValidationResult.fromPersistence(id, contentType, contentId, isValid, Collections.emptyList(), createdAt);
+        ValidationResult validationResult = ValidationResult.fromPersistence(id, userId, contentType, contentId,
+                isValid, Collections.emptyList(), createdAt);
 
         validationResultRepository.create(validationResult);
 
         verify(jdbcTemplate, times(1)).update(
-                eq("INSERT INTO validation_result (id, content_id, content_type, is_valid, errors, created_at) VALUES (?, ?, ?, ?, ?, ?)"),
+                eq("INSERT INTO validation_result (id, user_id, content_id, content_type, is_valid, errors, " +
+                        "created_at) VALUES (?, ?, ?, ?, ?, ?)"),
                 eq(id),
+                eq(userId),
                 eq(contentId),
                 eq(contentType),
                 eq(isValid),

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationResultRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationResultRepositoryTest.java
@@ -48,7 +48,7 @@ class ValidationResultRepositoryTest {
 
         verify(jdbcTemplate, times(1)).update(
                 eq("INSERT INTO validation_result (id, user_id, content_id, content_type, is_valid, errors, " +
-                        "created_at) VALUES (?, ?, ?, ?, ?, ?)"),
+                        "created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"),
                 eq(id),
                 eq(userId),
                 eq(contentId),

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -41,7 +41,8 @@ class ValidationControllerIntegrationTest {
 
         assertEquals(200, response.getStatusCode().value());
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId()
+                        , blogPost.getUserId())));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getContentType(), actual.getContentType());
@@ -64,7 +65,8 @@ class ValidationControllerIntegrationTest {
                 new ValidationError(LengthValidator.ERROR_CODE,
                         LengthValidator.errorMessageTooShort("title")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(), blogPost.getId(),validationErrors)));
+                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(),
+                        blogPost.getId(), blogPost.getUserId(), validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getContentType(), actual.getContentType());
@@ -87,7 +89,8 @@ class ValidationControllerIntegrationTest {
                 new ValidationError(LengthValidator.ERROR_CODE,
                         LengthValidator.errorMessageTooShort("content")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(), blogPost.getId(),
+                ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(),
+                        blogPost.getId(),  blogPost.getUserId(),
                         validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
@@ -112,7 +115,7 @@ class ValidationControllerIntegrationTest {
                         LengthValidator.errorMessageTooShort("content")));
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
                 ValidationResultDto.from(ValidationResult.invalid(blogPost.getClass().getSimpleName(),
-                        blogPost.getId(), validationErrors)));
+                        blogPost.getId(), blogPost.getUserId(), validationErrors)));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected, actual);
@@ -129,7 +132,7 @@ class ValidationControllerIntegrationTest {
 
         assertEquals(200, response.getStatusCode().value());
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId(), blogPost.getUserId())));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getValidationResult().getContentType(), actual.getValidationResult().getContentType());
@@ -149,7 +152,7 @@ class ValidationControllerIntegrationTest {
 
         assertEquals(200, response.getStatusCode().value());
         ValidationResponse expected = new ValidationResponse(BlogPost.class.getSimpleName(),
-                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId())));
+                ValidationResultDto.from(ValidationResult.valid(blogPost.getClass().getSimpleName(), blogPost.getId(), blogPost.getUserId())));
         ValidationResponse actual = response.getBody();
         assertNotNull(actual);
         assertEquals(expected.getValidationResult().getContentType(), actual.getValidationResult().getContentType());

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResponseTest.java
@@ -21,10 +21,14 @@ class ValidationResponseTest {
 
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
-        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, true, List.of(error1,
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, userId, true,
+                List.of(error1,
                 error2));
-        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId,true, List.of(error1, error2));
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId, userId, true,
+                List.of(error1,
+                error2));
 
         ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
         ValidationResponse response2 = new ValidationResponse("BlogPost", validationResult2);
@@ -39,10 +43,13 @@ class ValidationResponseTest {
 
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
-        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, true, List.of(error1,
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType, contentId, userId, true,
+                List.of(error1,
                 error2));
-        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId, false, List.of(error1));
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType, contentId, userId, false,
+                List.of(error1));
 
         ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
         ValidationResponse response2 = new ValidationResponse("BlogPost", validationResult2);
@@ -56,9 +63,10 @@ class ValidationResponseTest {
         String contentType2 = SupportRequest.class.getSimpleName();
         UUID contentId1 = UUID.randomUUID();
         UUID contentId2 = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
-        ValidationResultDto validationResult1 = new ValidationResultDto(contentType1, contentId1, true, null);
-        ValidationResultDto validationResult2 = new ValidationResultDto(contentType2, contentId2, true, null);
+        ValidationResultDto validationResult1 = new ValidationResultDto(contentType1, contentId1, userId, true, null);
+        ValidationResultDto validationResult2 = new ValidationResultDto(contentType2, contentId2, userId, true, null);
 
         ValidationResponse response1 = new ValidationResponse("BlogPost", validationResult1);
         ValidationResponse response2 = new ValidationResponse("Article", validationResult2);

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ValidationResultDtoTest.java
@@ -17,9 +17,10 @@ class ValidationResultDtoTest {
     void givenEqualValidationResultDtosWithNullError_whenEquals_thenReturnTrue() {
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
-        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, true, null);
-        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, true, null);
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, userId, true, null);
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, userId, true, null);
 
         assertEquals(dto1, dto2);
     }
@@ -28,9 +29,10 @@ class ValidationResultDtoTest {
     void givenDifferentValidationResultDtosWithNullError_whenEquals_thenReturnFalse() {
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
-        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, true, null);
-        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, null);
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, userId, true, null);
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, userId, false, null);
 
         assertNotEquals(dto1, dto2);
     }
@@ -39,12 +41,15 @@ class ValidationResultDtoTest {
     void givenEqualValidationResultDtosWithErrors_whenEquals_thenReturnTrue() {
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
 
-        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
-        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, userId, false, List.of(error1,
+                error2));
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, userId, false, List.of(error1,
+                error2));
 
         assertEquals(dto1, dto2);
     }
@@ -53,13 +58,16 @@ class ValidationResultDtoTest {
     void givenDifferentValidationResultDtosWithErrors_whenEquals_thenReturnFalse() {
         String contentType = BlogPost.class.getSimpleName();
         UUID contentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
 
         ValidationError error1 = new ValidationError("FIELD_1", "Error message 1");
         ValidationError error2 = new ValidationError("FIELD_2", "Error message 2");
         ValidationError error3 = new ValidationError("FIELD_3", "Error message 3");
 
-        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error2));
-        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, false, List.of(error1, error3));
+        ValidationResultDto dto1 = new ValidationResultDto(contentType, contentId, userId, false, List.of(error1,
+                error2));
+        ValidationResultDto dto2 = new ValidationResultDto(contentType, contentId, userId, false, List.of(error1,
+                error3));
 
         assertNotEquals(dto1, dto2);
     }


### PR DESCRIPTION
Closes #26 

This PR introduces the `userId` field for ValidationResult (and content entities) and prepares the codebase for per-user validation functionality.

New `ValidationResult` structure:
```java
public class ValidationResult {
    private final UUID id;
    private final UUID userId; // -> new field
    private final String contentType;
    private final UUID contentId;
    private final boolean isValid;
    private final List<ValidationError> errors;
    private final Instant createdAt;

    // ... more code
}
```