### PR TITLE
Fix Update ForbiddenWords Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,93 +171,53 @@ A Spring Boot service that helps create, manage, validate and moderate content. 
 }
 ```
 
-## Validation System
+### Forbidden Words Management
 
-The service includes a flexible validation pipeline system:
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/forbidden-words` | Get all forbidden words (includes system defaults) |
+| GET | `/api/forbidden-words/{id}` | Get forbidden words by ID |
+| POST | `/api/forbidden-words` | Create new forbidden words |
+| PUT | `/api/forbidden-words/{id}` | Update existing forbidden words |
+| DELETE | `/api/forbidden-words/{id}` | Delete forbidden words |
 
-### Available Validators
-
-- **LengthValidator**: Validates string length against min/max bounds
-
-### Usage Example
-
-```java
-ValidationPipeline pipeline = new BlockPostValidationPipeline();
-List<ValidationStep> steps = List.of(new LengthValidator(5, 100));
-boolean isValid = pipeline.runPipeline(content, steps);
+**Forbidden Words Model:**
+```json
+{
+  "id": "uuid",
+  "userId": "uuid",
+  "description": "string",
+  "contentType": "string",
+  "fieldName": "string",
+  "words": ["string"],
+  "createdAt": "timestamp",
+  "updatedAt": "timestamp"
+}
 ```
 
-## Configuration
+**Create/Update Request Examples:**
 
-### Application Profiles
-
-- **Default/Test Profile**: Uses H2 in-memory database
-- **Production Profile**: Uses MySQL database
-
-### Database Configuration
-
-The application automatically sets up the required database schema on startup. Schema files are located in `src/main/resources/schema.sql`.
-
-### Example Configuration (application.yml)
-
-```yaml
-spring:
-  profiles:
-    active: test
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop
+*Create Request:*
+```json
+{
+  "userId": "123e4567-e89b-12d3-a456-426614174000",
+  "description": "Inappropriate words for blog posts",
+  "contentType": "blogpost",
+  "fieldName": "content",
+  "words": ["badword1", "inappropriate", "spam"]
+}
 ```
 
-## Project Structure
-
+*Update Request (PUT - all fields required):*
+```json
+{
+  "id": "123e4567-e89b-12d3-a456-426614174001",
+  "userId": "123e4567-e89b-12d3-a456-426614174000",
+  "description": "Updated inappropriate words for blog posts",
+  "contentType": "blogpost",
+  "fieldName": "content",
+  "words": ["badword1", "inappropriate", "spam", "newbadword"]
+}
 ```
-src/
-├── main/java/com/dehold/contentmanager/
-│   ├── user/                      # User management
-│   ├── content/
-│   │   ├── blogpost/              # Blog post management
-│   │   └── customersupport/       # Customer support system
-│   └── validation/                # Validation framework
-└── test/                          # Test classes
-```
 
-## Development
-
-### Database Schema
-
-The service uses the following main tables:
-- `user` - User information
-- `blog_post` - Blog posts
-- `customer_request` - Customer support requests
-- `support_response` - Support team responses
-
-### Adding New Content Types
-
-1. Create model class in appropriate package
-2. Implement repository with JDBC operations
-3. Create service layer
-4. Add REST controller
-5. Write integration tests
-
-## Testing
-
-The project includes comprehensive test coverage:
-- Unit tests for service layers
-- Integration tests for REST endpoints
-- Validation pipeline tests
-
-Run specific test suites:
-```bash
-# Run all tests
-./mvnw test
-
-# Run specific test class
-./mvnw -Dtest=CustomerRequestControllerIntegrationTest test
-```
+> **Note:** PUT requests require all fields to be present. Missing fields will result in a 400 Bad Request with details about which fields are missing. The path ID must match the payload ID.

--- a/src/main/java/com/dehold/contentmanager/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dehold/contentmanager/exception/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
 
         CustomErrorResponse errorResponse = new CustomErrorResponse(
                 Instant.now(),
-                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.BAD_REQUEST.value(),
                 ex.getMessage(),
                 request.getDescription(false).replace("uri=", "")
         );

--- a/src/main/java/com/dehold/contentmanager/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dehold/contentmanager/exception/GlobalExceptionHandler.java
@@ -24,4 +24,18 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(InvalidPayloadException.class)
+    public ResponseEntity<CustomErrorResponse> handleEntityNotFoundException(
+            InvalidPayloadException ex, WebRequest request) {
+
+        CustomErrorResponse errorResponse = new CustomErrorResponse(
+                Instant.now(),
+                HttpStatus.NOT_FOUND.value(),
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/exception/InvalidPayloadException.java
+++ b/src/main/java/com/dehold/contentmanager/exception/InvalidPayloadException.java
@@ -1,0 +1,12 @@
+package com.dehold.contentmanager.exception;
+
+public class InvalidPayloadException extends RuntimeException {
+
+    public InvalidPayloadException(String message) {
+        super(message);
+    }
+
+    public static InvalidPayloadException of(String details) {
+        return new InvalidPayloadException(String.format("Invalid payload: %s", details));
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/exception/InvalidPayloadException.java
+++ b/src/main/java/com/dehold/contentmanager/exception/InvalidPayloadException.java
@@ -1,12 +1,7 @@
 package com.dehold.contentmanager.exception;
 
 public class InvalidPayloadException extends RuntimeException {
-
     public InvalidPayloadException(String message) {
         super(message);
-    }
-
-    public static InvalidPayloadException of(String details) {
-        return new InvalidPayloadException(String.format("Invalid payload: %s", details));
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
@@ -61,7 +61,7 @@ public class ForbiddenWordsService implements IService<ForbiddenWords> {
             throw new IllegalStateException("forbiddenWords.json not found on classpath");
         }
         try (InputStream inputStream = resource.getInputStream()) {
-            return objectMapper.readValue(resource.getInputStream(), new TypeReference<LinkedHashSet<String>>() {});
+            return objectMapper.readValue(inputStream, new TypeReference<>() {});
         } catch(IOException e) {
             throw new IllegalStateException("Failed to load default forbidden words", e);
         }
@@ -69,7 +69,11 @@ public class ForbiddenWordsService implements IService<ForbiddenWords> {
 
     @Override
     public ForbiddenWords update(UUID id, ForbiddenWords entity) {
-        findById(id);
+        ForbiddenWords existing = findById(id);
+
+        entity.setCreatedAt(existing.getCreatedAt());
+        entity.setUpdatedAt(java.time.Instant.now());
+
         repository.save(entity);
         return entity;
     }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ForbiddenWordsController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ForbiddenWordsController.java
@@ -43,6 +43,8 @@ public class ForbiddenWordsController {
 
     @PutMapping("/{id}")
     public ResponseEntity<ForbiddenWords> updateForbiddenWords(@PathVariable UUID id, @RequestBody ForbiddenWordsUpdateDto request) {
+        request.validateForUpdate();
+
         if (!id.equals(request.getId())) {
             throw new InvalidPayloadException("The path ID does not match payload ID.");
         }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ForbiddenWordsController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ForbiddenWordsController.java
@@ -1,7 +1,9 @@
 package com.dehold.contentmanager.validation.web;
 
+import com.dehold.contentmanager.exception.InvalidPayloadException;
 import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
+import com.dehold.contentmanager.validation.web.dto.ForbiddenWordsUpdateDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -40,8 +42,12 @@ public class ForbiddenWordsController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ForbiddenWords> updateForbiddenWords(@PathVariable UUID id, @RequestBody ForbiddenWords request) {
-        var forbiddenWords = forbiddenWordsService.update(id, request);
+    public ResponseEntity<ForbiddenWords> updateForbiddenWords(@PathVariable UUID id, @RequestBody ForbiddenWordsUpdateDto request) {
+        if (!id.equals(request.getId())) {
+            throw new InvalidPayloadException("The path ID does not match payload ID.");
+        }
+
+        var forbiddenWords = forbiddenWordsService.update(id, request.toForbiddenWords());
         return ResponseEntity.ok(forbiddenWords);
     }
 

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
@@ -52,7 +52,7 @@ public class ForbiddenWordsUpdateDto {
         );
     }
 
-    public void validateForUpdate() {
+    public void validateForUpdate() throws InvalidPayloadException {
         List<String> nullFields = new ArrayList<>();
 
         if (id == null) nullFields.add("id");

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
@@ -1,0 +1,100 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import com.dehold.contentmanager.validation.model.ForbiddenWords;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.UUID;
+
+public class ForbiddenWordsUpdateDto {
+    private UUID id;
+    private UUID userId;
+    private String description;
+    private String contentType;
+    private String fieldName;
+    private LinkedHashSet<String> words;
+
+    public ForbiddenWordsUpdateDto() {
+    }
+
+    public ForbiddenWordsUpdateDto(UUID id, UUID userId, String description, String contentType,
+                                   String fieldName, LinkedHashSet<String> words) {
+        this.id = id;
+        this.userId = userId;
+        this.description = description;
+        this.contentType = contentType;
+        this.fieldName = fieldName;
+        this.words = words;
+    }
+
+    public static ForbiddenWordsUpdateDto from(ForbiddenWords forbiddenWords) {
+        return new ForbiddenWordsUpdateDto(
+                forbiddenWords.getId(),
+                forbiddenWords.getUserId(),
+                forbiddenWords.getDescription(),
+                forbiddenWords.getContentType(),
+                forbiddenWords.getFieldName(),
+                forbiddenWords.getWords()
+        );
+    }
+
+    public ForbiddenWords toForbiddenWords() {
+        return new ForbiddenWords(
+                this.id,
+                this.userId,
+                this.description,
+                this.contentType,
+                this.fieldName,
+                this.words
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public LinkedHashSet<String> getWords() {
+        return words;
+    }
+
+    public void setWords(LinkedHashSet<String> words) {
+        this.words = words;
+    }
+    
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
@@ -115,21 +115,4 @@ public class ForbiddenWordsUpdateDto {
         this.words = words;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ForbiddenWordsUpdateDto that = (ForbiddenWordsUpdateDto) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(userId, that.userId) &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(contentType, that.contentType) &&
-                Objects.equals(fieldName, that.fieldName) &&
-                Objects.equals(words, that.words);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, userId, description, contentType, fieldName, words);
-    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDto.java
@@ -1,8 +1,11 @@
 package com.dehold.contentmanager.validation.web.dto;
 
+import com.dehold.contentmanager.exception.InvalidPayloadException;
 import com.dehold.contentmanager.validation.model.ForbiddenWords;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -47,6 +50,21 @@ public class ForbiddenWordsUpdateDto {
                 this.fieldName,
                 this.words
         );
+    }
+
+    public void validateForUpdate() {
+        List<String> nullFields = new ArrayList<>();
+
+        if (id == null) nullFields.add("id");
+        if (userId == null) nullFields.add("userId");
+        if (description == null) nullFields.add("description");
+        if (contentType == null) nullFields.add("contentType");
+        if (fieldName == null) nullFields.add("fieldName");
+        if (words == null) nullFields.add("words");
+
+        if (!nullFields.isEmpty()) {
+            throw new InvalidPayloadException("The following fields must not be null: " + String.join(", ", nullFields));
+        }
     }
 
     public UUID getId() {
@@ -96,5 +114,22 @@ public class ForbiddenWordsUpdateDto {
     public void setWords(LinkedHashSet<String> words) {
         this.words = words;
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ForbiddenWordsUpdateDto that = (ForbiddenWordsUpdateDto) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(userId, that.userId) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(contentType, that.contentType) &&
+                Objects.equals(fieldName, that.fieldName) &&
+                Objects.equals(words, that.words);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, userId, description, contentType, fieldName, words);
+    }
 }

--- a/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-get.bru
+++ b/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-get.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/forbidden-words/cd4be0ae-062c-4ab3-bf2c-2f8b2b1460ea
+  url: {{baseUrl}}/api/forbidden-words
   body: none
   auth: inherit
 }

--- a/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-getById.bru
+++ b/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-getById.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/forbidden-words/cd4be0ae-062c-4ab3-bf2c-2f8b2b1460ea
+  url: {{baseUrl}}/api/forbidden-words/7756f24f-f960-4e03-860a-9a9592e0f822
   body: none
   auth: inherit
 }

--- a/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-update.bru
+++ b/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-update.bru
@@ -12,6 +12,7 @@ put {
 
 body:json {
   {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
     "userId": "123e4567-e89b-12d3-a456-426614174000",
     "description": "Forbidden words for blog post content",
     "contentType": "blogpost",

--- a/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-update.bru
+++ b/src/main/resources/content-manager-requests/forbidden-words/forbidden-words-update.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: {{baseUrl}}/api/forbidden-words/7edb486a-64ee-44b1-aa54-038c2d5b18d8
+  url: {{baseUrl}}/api/forbidden-words/7756f24f-f960-4e03-860a-9a9592e0f822
   body: json
   auth: inherit
 }
@@ -16,7 +16,13 @@ body:json {
     "description": "Forbidden words for blog post content",
     "contentType": "blogpost",
     "fieldName": "content",
-    "words": ["spam", "inappropriate", "offensive", "badword", "new1", "new2"]
+    "words": [
+      "spam",
+      "inappropriate",
+      "offensive",
+      "badword",
+      "new"
+    ]
   }
   
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ForbiddenWordsControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ForbiddenWordsControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.dehold.contentmanager.validation.web;
 import com.dehold.contentmanager.exception.CustomErrorResponse;
 import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import com.dehold.contentmanager.validation.repository.ForbiddenWordsRepository;
+import com.dehold.contentmanager.validation.web.dto.ForbiddenWordsUpdateDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,11 +114,11 @@ class ForbiddenWordsControllerIntegrationTest {
         );
         forbiddenWordsRepository.save(original);
 
-        LinkedHashSet<String> updatedWords = originalWords;
+        LinkedHashSet<String> updatedWords = new LinkedHashSet<>(originalWords);
         updatedWords.add("newword1");
         updatedWords.add("newword2");
 
-        ForbiddenWords updateRequest = new ForbiddenWords(
+        ForbiddenWordsUpdateDto updateRequest = new ForbiddenWordsUpdateDto(
                 original.getId(),
                 original.getUserId(),
                 "Updated description",
@@ -126,7 +127,7 @@ class ForbiddenWordsControllerIntegrationTest {
                 updatedWords
         );
 
-        HttpEntity<ForbiddenWords> entity = new HttpEntity<>(updateRequest);
+        HttpEntity<ForbiddenWordsUpdateDto> entity = new HttpEntity<>(updateRequest);
         ResponseEntity<ForbiddenWords> response = restTemplate.exchange(
                 "http://localhost:" + port + "/api/forbidden-words/" + original.getId(),
                 HttpMethod.PUT,
@@ -136,6 +137,7 @@ class ForbiddenWordsControllerIntegrationTest {
 
         assertEquals(200, response.getStatusCode().value());
         assertNotNull(response.getBody());
+        assertEquals(original.getId(), response.getBody().getId());
         assertEquals(updateRequest.getDescription(), response.getBody().getDescription());
         assertEquals(updateRequest.getContentType(), response.getBody().getContentType());
         LinkedHashSet<String> updatedWordsResponse = response.getBody().getWords();

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDtoTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDtoTest.java
@@ -33,7 +33,7 @@ class ForbiddenWordsUpdateDtoTest {
         words.add("test");
 
         ForbiddenWordsUpdateDto dto = new ForbiddenWordsUpdateDto(
-                null, // id is null
+                null,
                 UUID.randomUUID(),
                 "Test description",
                 "blogpost",
@@ -48,12 +48,12 @@ class ForbiddenWordsUpdateDtoTest {
     @Test
     void validateForUpdate_shouldThrowExceptionWithMultipleNullFields() {
         ForbiddenWordsUpdateDto dto = new ForbiddenWordsUpdateDto(
-                null, // id is null
-                null, // userId is null
+                null,
+                null,
                 "Test description",
-                null, // contentType is null
+                null,
                 "content",
-                null  // words is null
+                null
         );
 
         InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, dto::validateForUpdate);

--- a/src/test/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDtoTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/dto/ForbiddenWordsUpdateDtoTest.java
@@ -1,0 +1,63 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import com.dehold.contentmanager.exception.InvalidPayloadException;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForbiddenWordsUpdateDtoTest {
+
+    @Test
+    void validateForUpdate_shouldPassWhenAllFieldsArePresent() {
+        LinkedHashSet<String> words = new LinkedHashSet<>();
+        words.add("test");
+
+        ForbiddenWordsUpdateDto dto = new ForbiddenWordsUpdateDto(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Test description",
+                "blogpost",
+                "content",
+                words
+        );
+
+        assertDoesNotThrow(dto::validateForUpdate);
+    }
+
+    @Test
+    void validateForUpdate_shouldThrowExceptionWhenIdIsNull() {
+        LinkedHashSet<String> words = new LinkedHashSet<>();
+        words.add("test");
+
+        ForbiddenWordsUpdateDto dto = new ForbiddenWordsUpdateDto(
+                null, // id is null
+                UUID.randomUUID(),
+                "Test description",
+                "blogpost",
+                "content",
+                words
+        );
+
+        InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, dto::validateForUpdate);
+        assertEquals("The following fields must not be null: id", exception.getMessage());
+    }
+
+    @Test
+    void validateForUpdate_shouldThrowExceptionWithMultipleNullFields() {
+        ForbiddenWordsUpdateDto dto = new ForbiddenWordsUpdateDto(
+                null, // id is null
+                null, // userId is null
+                "Test description",
+                null, // contentType is null
+                "content",
+                null  // words is null
+        );
+
+        InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, dto::validateForUpdate);
+        assertEquals("The following fields must not be null: id, userId, contentType, words", exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
Fixes #32 

This PR fixes the endpoint `{{baseUrl}}/api/forbidden-words/:id` for PUT requests. Now it behaves like follows:

In case of missing fields, it returns:
   ```json
   {
     "timestamp": "2025-10-31T15:35:51.110434Z",
     "httpStatusCode": 400,
     "error": "The following fields must not be null: id, description",
     "path": "/api/forbidden-words/7756f24f-f960-4e03-860a-9a9592e0f822"
   }
   ```

In case of non-matching ids, it returns:
   ```json
   {
     "timestamp": "2025-10-31T15:37:37.829691Z",
     "httpStatusCode": 400,
     "error": "The path ID does not match payload ID.",
     "path": "/api/forbidden-words/7756f24f-f960-4e03-860a-9a9592e0f822"
   }
   ```