### PR TITLE
Forbidden Word Validation Step

### DIFF
--- a/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
@@ -4,7 +4,6 @@ import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
@@ -75,6 +74,12 @@ public class ForbiddenWordsRepository {
                 "DELETE FROM forbidden_words WHERE id = ?",
                 forbiddenWords.getId()
         );
+    }
+
+    public ForbiddenWords findByUserId(UUID userId) {
+        String sql = "SELECT * FROM forbidden_words WHERE user_id = ?";
+        return jdbcTemplate.query(sql, FORBIDDEN_WORDS_ROW_MAPPER, userId).stream().findFirst()
+                .orElse(null);
     }
 
     private static class ForbiddenWordsRowMapper implements RowMapper<ForbiddenWords> {

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
@@ -76,9 +76,9 @@ public class ForbiddenWordsRepository {
         );
     }
 
-    public ForbiddenWords findByUserId(UUID userId) {
-        String sql = "SELECT * FROM forbidden_words WHERE user_id = ?";
-        return jdbcTemplate.query(sql, FORBIDDEN_WORDS_ROW_MAPPER, userId).stream().findFirst()
+    public ForbiddenWords findByUserIdAndContentType(UUID userId, String contentType) {
+        String sql = "SELECT * FROM forbidden_words WHERE user_id = ? AND content_type = ?";
+        return jdbcTemplate.query(sql, FORBIDDEN_WORDS_ROW_MAPPER, userId, contentType).stream().findFirst()
                 .orElse(null);
     }
 

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepository.java
@@ -13,7 +13,7 @@ public class ForbiddenWordsRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    private final ForbiddenWordsRowMapper FORBIDDEN_WORDS_ROW_MAPPER = new ForbiddenWordsRowMapper();
+    protected final ForbiddenWordsRowMapper FORBIDDEN_WORDS_ROW_MAPPER = new ForbiddenWordsRowMapper();
 
     public ForbiddenWordsRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;

--- a/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
@@ -43,7 +43,7 @@ public class ForbiddenWordsService implements IService<ForbiddenWords> {
     }
 
     public List<ForbiddenWords> findByUserIdAndContentType(UUID userId, String contentType) {
-        ForbiddenWords customForbiddenWords = repository.findByUserId(userId);
+        ForbiddenWords customForbiddenWords = repository.findByUserIdAndContentType(userId, contentType);
         return addDefaultForbiddenWords(List.of(customForbiddenWords));
     }
 

--- a/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
@@ -42,7 +42,7 @@ public class ForbiddenWordsService implements IService<ForbiddenWords> {
         return addDefaultForbiddenWords(forbiddenWords);
     }
 
-    public List<ForbiddenWords> findByUserId(UUID userId) {
+    public List<ForbiddenWords> findByUserIdAndContentType(UUID userId, String contentType) {
         ForbiddenWords customForbiddenWords = repository.findByUserId(userId);
         return addDefaultForbiddenWords(List.of(customForbiddenWords));
     }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ForbiddenWordsService.java
@@ -42,6 +42,11 @@ public class ForbiddenWordsService implements IService<ForbiddenWords> {
         return addDefaultForbiddenWords(forbiddenWords);
     }
 
+    public List<ForbiddenWords> findByUserId(UUID userId) {
+        ForbiddenWords customForbiddenWords = repository.findByUserId(userId);
+        return addDefaultForbiddenWords(List.of(customForbiddenWords));
+    }
+
     private List<ForbiddenWords> addDefaultForbiddenWords(List<ForbiddenWords> customForbiddenWords) {
         ForbiddenWords defaultForbiddenWords =
                 new ForbiddenWords(

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -1,12 +1,16 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
+import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component
 public class ForbiddenWordValidator<T extends Content> implements ValidationStep<T> {
@@ -15,6 +19,7 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
     private final Function<T, String> getter;
     private final String fieldName;
     private final UUID userId;
+    public static final String ERROR_CODE = "FORBIDDEN_WORD_VALIDATION_FAILED";
 
     public ForbiddenWordValidator(ForbiddenWordsService service, Function<T, String> getter, String fieldName,
                                   UUID userId) {
@@ -27,7 +32,26 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
 
     @Override
     public ValidationResult validate(T content) {
+        List<ForbiddenWords> forbiddenWordsList = service.findByUserId(content.getUserId());
+        Set<String> forbiddenWords =
+                forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
+        String field = getter.apply(content);
+        for(String word : forbiddenWords) {
+            if(field != null && field.contains(word)) {
+                return ValidationResult.invalid(content.getClass().getSimpleName(),
+                        content.getId(),
+                        content.getUserId(),
+                        List.of(new com.dehold.contentmanager.validation.model.ValidationError(
+                                ERROR_CODE,
+                                "The field '" + fieldName + "' contains a forbidden word: '" + word + "'"
+                        )));
+            }
+        }
         return ValidationResult.valid(content.getClass().getSimpleName(), content.getId(), content.getUserId());
+    }
+
+    public String errorMessage(String fieldName, String forbiddenWord) {
+        return "The field '" + fieldName + "' contains the forbidden word: '" + forbiddenWord + "'";
     }
 
     @Override

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -2,6 +2,7 @@ package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ForbiddenWords;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.springframework.stereotype.Component;
@@ -34,15 +35,15 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
         List<ForbiddenWords> forbiddenWordsList = service.findByUserId(content.getUserId());
         Set<String> forbiddenWords =
                 forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
-        String field = getter.apply(content);
+        String value = getter.apply(content);
         for(String word : forbiddenWords) {
-            if(field != null && field.contains(word)) {
+            if(value != null && value.contains(word)) {
                 return ValidationResult.invalid(content.getClass().getSimpleName(),
                         content.getId(),
                         content.getUserId(),
-                        List.of(new com.dehold.contentmanager.validation.model.ValidationError(
+                        List.of(new ValidationError(
                                 ERROR_CODE,
-                                "The field '" + fieldName + "' contains a forbidden word: '" + word + "'"
+                                errorMessage(fieldName, word)
                         )));
             }
         }

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -2,17 +2,23 @@ package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ValidationResult;
+import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
+import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 import java.util.function.Function;
 
+@Component
 public class ForbiddenWordValidator<T extends Content> implements ValidationStep<T> {
 
+    private final ForbiddenWordsService service;
     private final Function<T, String> getter;
     private final String fieldName;
     private final UUID userId;
 
-    public ForbiddenWordValidator(Function<T, String> getter, String fieldName, UUID userId) {
+    public ForbiddenWordValidator(ForbiddenWordsService service, Function<T, String> getter, String fieldName,
+                                  UUID userId) {
+        this.service = service;
         this.getter = getter;
         this.fieldName = fieldName;
         this.userId = userId;

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -5,7 +5,6 @@ import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Set;
@@ -32,7 +31,8 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
 
     @Override
     public ValidationResult validate(T content) {
-        List<ForbiddenWords> forbiddenWordsList = service.findByUserId(content.getUserId());
+        String contentType = content.getClass().getSimpleName().toLowerCase();
+        List<ForbiddenWords> forbiddenWordsList = service.findByUserIdAndContentType(content.getUserId(), contentType);
         Set<String> forbiddenWords =
                 forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
         String value = getter.apply(content);

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@Component
 public class ForbiddenWordValidator<T extends Content> implements ValidationStep<T> {
 
     private final ForbiddenWordsService service;

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -1,0 +1,28 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.content.Content;
+import com.dehold.contentmanager.validation.model.ValidationResult;
+
+import java.util.function.Function;
+
+public class ForbiddenWordValidator<T extends Content> implements ValidationStep<T> {
+
+    private final Function<T, String> getter;
+    private final String fieldName;
+
+    public ForbiddenWordValidator(Function<T, String> getter, String fieldName) {
+        this.getter = getter;
+        this.fieldName = fieldName;
+    }
+
+
+    @Override
+    public ValidationResult validate(T content) {
+        return null;
+    }
+
+    @Override
+    public String getFieldName() {
+        return "";
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -27,7 +27,7 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
 
     @Override
     public ValidationResult validate(T content) {
-        return null;
+        return ValidationResult.valid(content.getClass().getSimpleName(), content.getId(), content.getUserId());
     }
 
     @Override

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -3,16 +3,19 @@ package com.dehold.contentmanager.validation.step;
 import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 
+import java.util.UUID;
 import java.util.function.Function;
 
 public class ForbiddenWordValidator<T extends Content> implements ValidationStep<T> {
 
     private final Function<T, String> getter;
     private final String fieldName;
+    private final UUID userId;
 
-    public ForbiddenWordValidator(Function<T, String> getter, String fieldName) {
+    public ForbiddenWordValidator(Function<T, String> getter, String fieldName, UUID userId) {
         this.getter = getter;
         this.fieldName = fieldName;
+        this.userId = userId;
     }
 
 
@@ -23,6 +26,10 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
 
     @Override
     public String getFieldName() {
-        return "";
+        return fieldName;
+    }
+
+    public UUID getUserId() {
+        return userId;
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -1,0 +1,24 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.content.Content;
+import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.function.Function;
+
+@Component
+public class ValidationStepFactory {
+
+    private final ForbiddenWordsService forbiddenWordsService;
+
+    public ValidationStepFactory(ForbiddenWordsService forbiddenWordsService) {
+        this.forbiddenWordsService = forbiddenWordsService;
+    }
+
+    public <T extends Content> ForbiddenWordValidator<T> createForbiddenWordValidator(
+            Function<T, String> getter, String fieldName, UUID userId) {
+        return new ForbiddenWordValidator<>(forbiddenWordsService, getter, fieldName, userId);
+    }
+}
+

--- a/src/main/resources/forbiddenWords.json
+++ b/src/main/resources/forbiddenWords.json
@@ -1,6 +1,6 @@
 [
-  "stupid",
-  "dumb",
-  "idiot",
-  "hate"
-]
+  "offensiveWord1",
+  "offensiveWord2",
+  "offensiveWord3",
+  "offensiveWord4"
+  ]

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ForbiddenWordsRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.dehold.contentmanager.validation.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ForbiddenWordsRepositoryTest {
+
+    @Mock
+    JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    ForbiddenWordsRepository cut;
+
+    @Test
+    void whenQueryForbiddenWordsByUserAndContentType_thenCallJdbcTemplateWithRightArguments() {
+        UUID userId = UUID.randomUUID();
+        String contentType = "blogpost";
+
+        cut.findByUserIdAndContentType(userId, contentType);
+
+        verify(jdbcTemplate, times(1)).query(
+                "SELECT * FROM forbidden_words WHERE user_id = ? AND content_type = ?",
+                cut.FORBIDDEN_WORDS_ROW_MAPPER,
+                userId,
+                contentType
+        );
+    }
+}

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -6,8 +6,10 @@ import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ForbiddenWordValidatorTest {
 
     @Mock
@@ -39,7 +42,7 @@ class ForbiddenWordValidatorTest {
     @BeforeEach
     void setup() {
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
-        when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
+        //when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -1,0 +1,53 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.validation.model.ForbiddenWords;
+import com.dehold.contentmanager.validation.model.ValidationResult;
+import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ForbiddenWordValidatorTest {
+
+    @Mock
+    ForbiddenWordsService forbiddenWordsService;
+
+    @InjectMocks
+    ForbiddenWordValidator<BlogPost> cut;
+
+    ForbiddenWords defaultForbiddenWords = new ForbiddenWords(null, null, "Default Forbidden Words", "any", "any",
+            new java.util.LinkedHashSet<>(java.util.Arrays.asList("badword1", "badword2")));
+    ForbiddenWords customForbiddenWords = new ForbiddenWords(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "Custom Forbidden Words",
+            "blogpost",
+            "content",
+            new java.util.LinkedHashSet<>(java.util.Arrays.asList("custombadword1", "custombadword2"))
+    );
+
+    @BeforeEach
+    void setup() {
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
+    }
+
+    @Test
+    void givenBlogPostWithNoForbiddenWords_whenValidate_thenReturnValidResult() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This is a clean blog post content.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        assertTrue(result.isValid());
+    }
+
+}

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -43,9 +43,6 @@ class ForbiddenWordValidatorTest {
 
     @BeforeEach
     void setup() {
-        Function<BlogPost, String> getter = BlogPost::getContent;
-        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
-        cut = factory.createForbiddenWordValidator(getter, "content", UUID.randomUUID());
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
         when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
@@ -55,7 +52,13 @@ class ForbiddenWordValidatorTest {
     void givenContentWithNoForbiddenWords_whenValidate_thenReturnValidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This is a clean blog post content.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         assertTrue(result.isValid());
     }
 
@@ -63,7 +66,13 @@ class ForbiddenWordValidatorTest {
     void givenContentWithDefaultForbiddenWord_whenValidate_thenReturnInvalidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         assertFalse(result.isValid());
     }
 
@@ -71,7 +80,14 @@ class ForbiddenWordValidatorTest {
     void givenContentWithCustomForbiddenWord_whenValidate_thenReturnInvalidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains custombadword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         assertFalse(result.isValid());
     }
 
@@ -79,7 +95,14 @@ class ForbiddenWordValidatorTest {
     void givenContentWithForbiddenWords_whenValidate_thenErrorCodeIsCorrect() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some Title", "This content contains badword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         String expected = ForbiddenWordValidator.ERROR_CODE;
         String actual = result.getErrors().getFirst().code();
         assertEquals(expected, actual);
@@ -89,7 +112,14 @@ class ForbiddenWordValidatorTest {
     void givenContentWithForbiddenWords_whenValidate_thenErrorMessageIsCorrect() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some Title", "This content contains badword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         String expected = cut.errorMessage("content", "badword1");
         String actual = result.getErrors().getFirst().message();
         assertEquals(expected, actual);
@@ -100,7 +130,13 @@ class ForbiddenWordValidatorTest {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Title with a badword1", "But actually only the content " +
                 "is checked.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
         ValidationResult result = cut.validate(blogPost);
+
         assertTrue(result.isValid());
     }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,8 +42,10 @@ class ForbiddenWordValidatorTest {
 
     @BeforeEach
     void setup() {
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        cut = new ForbiddenWordValidator<BlogPost>(forbiddenWordsService, getter, "content", UUID.randomUUID());
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
-        //when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
+        when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
     }
 
     @Test
@@ -51,6 +54,22 @@ class ForbiddenWordValidatorTest {
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
         assertTrue(result.isValid());
+    }
+
+    @Test
+    void givenBlogPostWithDefaultForbiddenWord_whenValidate_thenReturnInvalidResult() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void givenBlogPostWithCustomForbiddenWord_whenValidate_thenReturnInvalidResult() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains custombadword1.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        assertFalse(result.isValid());
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,7 +47,8 @@ class ForbiddenWordValidatorTest {
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         cut = factory.createForbiddenWordValidator(getter, "content", UUID.randomUUID());
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
-        when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
     }
 
     @Test
@@ -71,6 +73,16 @@ class ForbiddenWordValidatorTest {
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
         assertFalse(result.isValid());
+    }
+
+    @Test
+    void givenContentWithForbiddenWords_whenValidate_thenErrorCodeIsCorrect() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some Title", "This content contains badword1.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        String expected = cut.ERROR_CODE;
+        String actual = result.getErrors().getFirst().code();
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -80,7 +80,7 @@ class ForbiddenWordValidatorTest {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some Title", "This content contains badword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
-        String expected = cut.ERROR_CODE;
+        String expected = ForbiddenWordValidator.ERROR_CODE;
         String actual = result.getErrors().getFirst().code();
         assertEquals(expected, actual);
     }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -50,7 +50,7 @@ class ForbiddenWordValidatorTest {
     }
 
     @Test
-    void givenBlogPostWithNoForbiddenWords_whenValidate_thenReturnValidResult() {
+    void givenContentWithNoForbiddenWords_whenValidate_thenReturnValidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This is a clean blog post content.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
@@ -58,7 +58,7 @@ class ForbiddenWordValidatorTest {
     }
 
     @Test
-    void givenBlogPostWithDefaultForbiddenWord_whenValidate_thenReturnInvalidResult() {
+    void givenContentWithDefaultForbiddenWord_whenValidate_thenReturnInvalidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
@@ -66,11 +66,20 @@ class ForbiddenWordValidatorTest {
     }
 
     @Test
-    void givenBlogPostWithCustomForbiddenWord_whenValidate_thenReturnInvalidResult() {
+    void givenContentWithCustomForbiddenWord_whenValidate_thenReturnInvalidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains custombadword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());
         ValidationResult result = cut.validate(blogPost);
         assertFalse(result.isValid());
     }
 
+    @Test
+    void givenContentWithForbiddenWords_whenValidate_thenErrorMessageIsCorrect() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some Title", "This content contains badword1.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        String expected = cut.errorMessage("content", "badword1");
+        String actual = result.getErrors().getFirst().message();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -94,4 +94,13 @@ class ForbiddenWordValidatorTest {
         String actual = result.getErrors().getFirst().message();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void givenFieldThatWasNotSpecifiedContainsForbiddenWords_whenValidate_thenReturnValidResult() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Title with a badword1", "But actually only the content " +
+                "is checked.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        ValidationResult result = cut.validate(blogPost);
+        assertTrue(result.isValid());
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -43,7 +43,8 @@ class ForbiddenWordValidatorTest {
     @BeforeEach
     void setup() {
         Function<BlogPost, String> getter = BlogPost::getContent;
-        cut = new ForbiddenWordValidator<BlogPost>(forbiddenWordsService, getter, "content", UUID.randomUUID());
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        cut = factory.createForbiddenWordValidator(getter, "content", UUID.randomUUID());
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         when(forbiddenWordsService.findByUserId(any(UUID.class))).thenReturn(forbiddenWordsList);
     }

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -139,4 +139,21 @@ class ForbiddenWordValidatorTest {
 
         assertTrue(result.isValid());
     }
+
+    @Test
+    void givenContent_whenValidated_thenValidationResultContainsGenericInfos() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Some title", "Some content.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        ValidationResult result = cut.validate(blogPost);
+
+        assertEquals(result.getContentType(), blogPost.getClass().getSimpleName());
+        assertEquals(result.getContentId(), blogPost.getId());
+        assertEquals(result.getUserId(), blogPost.getUserId());
+    }
 }


### PR DESCRIPTION
Closes #34 

This PR adds support for forbidden-words-validations. Forbidden words can be specified like so:

```json
  {
    "userId": "af202a82-52cc-4ac7-be2a-930ab96608de",
    "description": "Forbidden words for blog post content",
    "contentType": "blogpost",
    "fieldName": "content",
    "words": ["spam", "inappropriate", "offensive", "badword"]
  }
```

When running the validation via `ForbiddenWordValidator.validate()`, a result in case of violations might look like this:

```json
  {
    "contentType": "BlogPost",
    "validationResult": {
      "contentType": "BlogPost",
      "contentId": "87b85bfe-ea69-4ee6-834e-9c84dd007d4f",
      "userId": "af202a82-52cc-4ac7-be2a-930ab96608de",
      "valid": false,
      "errors": [
        {
          "code": "FORBIDDEN_WORD_VALIDATION_FAILED",
          "message": "The field 'content' contains the forbidden word: 'badword'"
        }
      ]
    }
  }
```