### PR TITLE
Fix Forbidden Words Validation

### DIFF
--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -32,10 +32,25 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
 
     @Override
     public ValidationResult validate(T content) {
-        String contentType = content.getClass().getSimpleName().toLowerCase();
-        List<ForbiddenWords> forbiddenWordsList = service.findByUserIdAndContentType(content.getUserId(), contentType);
-        Set<String> forbiddenWords =
-                forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
+        Set<String> forbiddenWords = fetchForbiddenWords(content);
+        List<String> foundViolations = findViolations(content, forbiddenWords);
+        if(!foundViolations.isEmpty()) {
+            return buildInvalidValidationResult(content, foundViolations);
+        }
+        return ValidationResult.valid(content.getClass().getSimpleName(), content.getId(), content.getUserId());
+    }
+
+    private ValidationResult buildInvalidValidationResult(T content, List<String> foundViolations) {
+        return ValidationResult.invalid(content.getClass().getSimpleName(),
+                content.getId(),
+                content.getUserId(),
+                List.of(new ValidationError(
+                        ERROR_CODE,
+                        errorMessage(fieldName, foundViolations)
+                )));
+    }
+
+    private List<String> findViolations(T content, Set<String> forbiddenWords) {
         String value = getter.apply(content);
         List<String> foundViolations = new ArrayList<>();
         for(String word : forbiddenWords) {
@@ -43,16 +58,15 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
                 foundViolations.add(word);
             }
         }
-        if(!foundViolations.isEmpty()) {
-            return ValidationResult.invalid(content.getClass().getSimpleName(),
-                    content.getId(),
-                    content.getUserId(),
-                    List.of(new ValidationError(
-                            ERROR_CODE,
-                            errorMessage(fieldName, foundViolations)
-                    )));
-        }
-        return ValidationResult.valid(content.getClass().getSimpleName(), content.getId(), content.getUserId());
+        return foundViolations;
+    }
+
+    private Set<String> fetchForbiddenWords(T content) {
+        String contentType = content.getClass().getSimpleName().toLowerCase();
+        List<ForbiddenWords> forbiddenWordsList = service.findByUserIdAndContentType(content.getUserId(), contentType);
+        Set<String> forbiddenWords =
+                forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
+        return forbiddenWords;
     }
 
     public String errorMessage(String fieldName, List<String> forbiddenWords) {

--- a/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidator.java
@@ -6,6 +6,7 @@ import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -36,22 +37,26 @@ public class ForbiddenWordValidator<T extends Content> implements ValidationStep
         Set<String> forbiddenWords =
                 forbiddenWordsList.stream().map(ForbiddenWords::getWords).flatMap(Set::stream).collect(Collectors.toSet());
         String value = getter.apply(content);
+        List<String> foundViolations = new ArrayList<>();
         for(String word : forbiddenWords) {
             if(value != null && value.contains(word)) {
-                return ValidationResult.invalid(content.getClass().getSimpleName(),
-                        content.getId(),
-                        content.getUserId(),
-                        List.of(new ValidationError(
-                                ERROR_CODE,
-                                errorMessage(fieldName, word)
-                        )));
+                foundViolations.add(word);
             }
+        }
+        if(!foundViolations.isEmpty()) {
+            return ValidationResult.invalid(content.getClass().getSimpleName(),
+                    content.getId(),
+                    content.getUserId(),
+                    List.of(new ValidationError(
+                            ERROR_CODE,
+                            errorMessage(fieldName, foundViolations)
+                    )));
         }
         return ValidationResult.valid(content.getClass().getSimpleName(), content.getId(), content.getUserId());
     }
 
-    public String errorMessage(String fieldName, String forbiddenWord) {
-        return "The field '" + fieldName + "' contains the forbidden word: '" + forbiddenWord + "'";
+    public String errorMessage(String fieldName, List<String> forbiddenWords) {
+        return "The field '" + fieldName + "' contains the forbidden words: " + String.join(", ", forbiddenWords);
     }
 
     @Override

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -134,6 +134,7 @@ class ForbiddenWordValidatorTest {
 
         assertTrue(result.getErrors().getFirst().message().contains("badword1"));
         assertTrue(result.getErrors().getFirst().message().contains("badword2"));
+        assertTrue(result.getErrors().getFirst().message().contains("custombadword1"));
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -77,6 +77,35 @@ class ForbiddenWordValidatorTest {
     }
 
     @Test
+    void givenContentWithSeveralForbiddenWords_whenValidate_thenReturnOneErrorObject() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1 and badword2.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        ValidationResult result = cut.validate(blogPost);
+
+        assertEquals(1, result.getErrors().size());
+    }
+
+    @Test
+    void givenContentWithSeveralForbiddenWords_whenValidate_thenReturnErrorMessageWithAllWords() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1 and badword2.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        ValidationResult result = cut.validate(blogPost);
+
+        assertTrue(result.getErrors().getFirst().message().contains("badword1"));
+        assertTrue(result.getErrors().getFirst().message().contains("badword2"));
+    }
+
+    @Test
     void givenContentWithCustomForbiddenWord_whenValidate_thenReturnInvalidResult() {
         BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains custombadword1.",
                 Instant.now(), Instant.now(), UUID.randomUUID());

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -12,6 +12,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
@@ -31,22 +33,15 @@ class ForbiddenWordValidatorTest {
     ForbiddenWordValidator<BlogPost> cut;
 
     ForbiddenWords defaultForbiddenWords = new ForbiddenWords(null, null, "Default Forbidden Words", "any", "any",
-            new java.util.LinkedHashSet<>(java.util.Arrays.asList("badword1", "badword2")));
+            new LinkedHashSet<>(Arrays.asList("badword1", "badword2")));
     ForbiddenWords customForbiddenWords = new ForbiddenWords(
             UUID.randomUUID(),
             UUID.randomUUID(),
             "Custom Forbidden Words",
             "blogpost",
             "content",
-            new java.util.LinkedHashSet<>(java.util.Arrays.asList("custombadword1", "custombadword2"))
+            new LinkedHashSet<>(Arrays.asList("custombadword1", "custombadword2"))
     );
-
-    @BeforeEach
-    void setup() {
-        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
-        String contentType = BlogPost.class.getSimpleName().toLowerCase();
-        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
-    }
 
     @Test
     void givenContentWithNoForbiddenWords_whenValidate_thenReturnValidResult() {
@@ -56,6 +51,10 @@ class ForbiddenWordValidatorTest {
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
 
         ValidationResult result = cut.validate(blogPost);
 
@@ -71,6 +70,10 @@ class ForbiddenWordValidatorTest {
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
 
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
         ValidationResult result = cut.validate(blogPost);
 
         assertFalse(result.isValid());
@@ -85,6 +88,10 @@ class ForbiddenWordValidatorTest {
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
 
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
         ValidationResult result = cut.validate(blogPost);
 
         assertEquals(1, result.getErrors().size());
@@ -98,6 +105,30 @@ class ForbiddenWordValidatorTest {
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
+        ValidationResult result = cut.validate(blogPost);
+
+        assertTrue(result.getErrors().getFirst().message().contains("badword1"));
+        assertTrue(result.getErrors().getFirst().message().contains("badword2"));
+    }
+
+    @Test
+    void givenContentWithMixOfDefaultAndCustomForbiddenWords_whenValidate_thenReturnErrorMessageWithAllWords() {
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(),"Some Title", "This content contains badword1 and badword2" +
+                " and custombadword1.",
+                Instant.now(), Instant.now(), UUID.randomUUID());
+        Function<BlogPost, String> getter = BlogPost::getContent;
+        ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
+        String fieldThatShouldBeValidated = "content";
+        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
 
         ValidationResult result = cut.validate(blogPost);
 
@@ -115,6 +146,10 @@ class ForbiddenWordValidatorTest {
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
 
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
         ValidationResult result = cut.validate(blogPost);
 
         assertFalse(result.isValid());
@@ -129,6 +164,10 @@ class ForbiddenWordValidatorTest {
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
 
         ValidationResult result = cut.validate(blogPost);
 
@@ -168,10 +207,15 @@ class ForbiddenWordValidatorTest {
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
 
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
         ValidationResult result = cut.validate(blogPost);
 
         assertTrue(result.isValid());
     }
+
 
     @Test
     void givenContent_whenValidated_thenValidationResultContainsGenericInfos() {
@@ -182,6 +226,10 @@ class ForbiddenWordValidatorTest {
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
 
         ValidationResult result = cut.validate(blogPost);
 

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -147,9 +147,13 @@ class ForbiddenWordValidatorTest {
         String fieldThatShouldBeValidated = "content";
         cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
 
+        List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
+        String contentType = BlogPost.class.getSimpleName().toLowerCase();
+        when(forbiddenWordsService.findByUserIdAndContentType(any(UUID.class), eq(contentType))).thenReturn(forbiddenWordsList);
+
         ValidationResult result = cut.validate(blogPost);
 
-        String expected = cut.errorMessage("content", "badword1");
+        String expected = cut.errorMessage("content", List.of("badword1"));
         String actual = result.getErrors().getFirst().message();
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
Fixes #36 

This PR fixes the forbidden words validation: Now, all word violations are part of the error message. Before, only one word was listed in the error message, even though there were several violations.

Example error message:
```java
The field 'content' contains the forbidden words: forbidden1, forbidden2, forbidden3
```
