### PR TITLE
Streamline ValidationStep Creation

### DIFF
--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
@@ -1,0 +1,7 @@
+package com.dehold.contentmanager.validation.model;
+
+public enum ValidationStepType {
+    FORBIDDEN_WORD_VALIDATION,
+    LENGTH_VALIDATION,
+    PHONE_NUMBER_VALIDATION
+}

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
@@ -3,5 +3,5 @@ package com.dehold.contentmanager.validation.model;
 public enum ValidationStepType {
     FORBIDDEN_WORD_VALIDATION,
     LENGTH_VALIDATION,
-    PHONE_NUMBER_VALIDATION
+    PHONE_NUMBER_FORBIDDEN_VALIDATION
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -1,17 +1,21 @@
 package com.dehold.contentmanager.validation.service;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipeline;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipelineBuilder;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
 import com.dehold.contentmanager.validation.step.LengthValidator;
+import com.dehold.contentmanager.validation.step.ValidationStep;
+import com.dehold.contentmanager.validation.step.ValidationStepFactory;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -25,9 +29,12 @@ public class ValidationServiceImpl implements ValidationService {
 
     @Override
     public ValidationResponse validateBlogPost(BlogPostValidationRequest request) {
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+        ValidationStep<BlogPost> titleLengthValidator = getTitleLengthValidator(request, factory);
+        ValidationStep<BlogPost> contentLengthValidator = getBlogPostLengthValidator(request, factory);
         ValidationPipeline<BlogPost> pipeline = new ValidationPipelineBuilder<BlogPost>()
-                .addStep(new LengthValidator<>(BlogPost::getTitle, "title", request.getTitleMinLength(), request.getTitleMaxLength()))
-                .addStep(new LengthValidator<>(BlogPost::getContent, "content", request.getContentMinLength(), request.getContentMaxLength()))
+                .addStep(titleLengthValidator)
+                .addStep(contentLengthValidator)
                 .build();
         ValidationResult result = pipeline.run(request.getBlogPost());
 
@@ -35,6 +42,18 @@ public class ValidationServiceImpl implements ValidationService {
 
         ValidationResultDto resultDto = ValidationResultDto.from(result);
         return new ValidationResponse(BlogPost.class.getSimpleName(), resultDto);
+    }
+
+    private static ValidationStep<BlogPost> getBlogPostLengthValidator(BlogPostValidationRequest request, ValidationStepFactory factory) {
+        return factory.createValidationStep(ValidationStepType.LENGTH_VALIDATION, BlogPost::getContent,
+                Map.of("minLength", String.valueOf(request.getContentMinLength()), "maxLength",
+                        String.valueOf(request.getContentMaxLength())), "content", null);
+    }
+
+    private static ValidationStep<BlogPost> getTitleLengthValidator(BlogPostValidationRequest request, ValidationStepFactory factory) {
+        return factory.createValidationStep(ValidationStepType.LENGTH_VALIDATION, BlogPost::getTitle,
+                Map.of("minLength", String.valueOf(request.getTitleMinLength()), "maxLength",
+                        String.valueOf(request.getTitleMaxLength())), "title", null);
     }
 
     @Override

--- a/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/LengthValidator.java
@@ -41,6 +41,11 @@ public class LengthValidator<T extends Content> implements ValidationStep<T> {
                 content.getId(), content.getUserId());
     }
 
+    @Override
+    public String getFieldName() {
+        return this.fieldName;
+    }
+
     public static String errorMessageTooShort(String fieldName) {
         return "The field '" + fieldName + "' is too short.";
     }
@@ -49,8 +54,11 @@ public class LengthValidator<T extends Content> implements ValidationStep<T> {
         return "The field '" + fieldName + "' is too long.";
     }
 
-    @Override
-    public String getFieldName() {
-        return this.fieldName;
+    public int getMinLength() {
+        return minLength;
+    }
+
+    public int getMaxLength() {
+        return maxLength;
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -1,9 +1,11 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -14,6 +16,22 @@ public class ValidationStepFactory {
 
     public ValidationStepFactory(ForbiddenWordsService forbiddenWordsService) {
         this.forbiddenWordsService = forbiddenWordsService;
+    }
+
+    public <T extends Content> ValidationStep<T> createValidationStep(ValidationStepType type,
+                                                                     Function<T, String> fieldExtractor, Map<String,
+                    String> params, String fieldName, UUID userId) {
+        return switch (type) {
+            case FORBIDDEN_WORD_VALIDATION ->
+                    createForbiddenWordValidator(fieldExtractor, fieldName, userId);
+            case LENGTH_VALIDATION -> {
+                int minLength = Integer.parseInt(params.get("minLength"));
+                int maxLength = Integer.parseInt(params.get("maxLength"));
+                yield createLengthValidator(fieldExtractor, fieldName, minLength, maxLength);
+            }
+            case PHONE_NUMBER_FORBIDDEN_VALIDATION ->
+                    createPhoneNumberValidator(fieldExtractor, fieldName);
+        };
     }
 
     public <T extends Content> ForbiddenWordValidator<T> createForbiddenWordValidator(

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -20,5 +20,15 @@ public class ValidationStepFactory {
             Function<T, String> getter, String fieldName, UUID userId) {
         return new ForbiddenWordValidator<>(forbiddenWordsService, getter, fieldName, userId);
     }
+
+    public <T extends Content> LengthValidator<T> createLengthValidator(
+            Function<T, String> getter, String fieldName, int minLength, int maxLength) {
+        return new LengthValidator<>(getter, fieldName, minLength, maxLength);
+    }
+
+    public <T extends Content> PhoneNumberForbiddenValidator<T> createPhoneNumberValidator(
+            Function<T, String> getter, String fieldName) {
+        return new PhoneNumberForbiddenValidator<>(getter, fieldName);
+    }
 }
 

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -34,17 +34,17 @@ public class ValidationStepFactory {
         };
     }
 
-    public <T extends Content> ForbiddenWordValidator<T> createForbiddenWordValidator(
+    private <T extends Content> ForbiddenWordValidator<T> createForbiddenWordValidator(
             Function<T, String> getter, String fieldName, UUID userId) {
         return new ForbiddenWordValidator<>(forbiddenWordsService, getter, fieldName, userId);
     }
 
-    public <T extends Content> LengthValidator<T> createLengthValidator(
+    private <T extends Content> LengthValidator<T> createLengthValidator(
             Function<T, String> getter, String fieldName, int minLength, int maxLength) {
         return new LengthValidator<>(getter, fieldName, minLength, maxLength);
     }
 
-    public <T extends Content> PhoneNumberForbiddenValidator<T> createPhoneNumberValidator(
+    private <T extends Content> PhoneNumberForbiddenValidator<T> createPhoneNumberValidator(
             Function<T, String> getter, String fieldName) {
         return new PhoneNumberForbiddenValidator<>(getter, fieldName);
     }

--- a/src/test/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/pipeline/ValidationPipelineTest.java
@@ -2,9 +2,11 @@ package com.dehold.contentmanager.validation.pipeline;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.model.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.step.PhoneNumberForbiddenValidator;
 import com.dehold.contentmanager.validation.step.ValidationStep;
+import com.dehold.contentmanager.validation.step.ValidationStepFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,7 +50,8 @@ class ValidationPipelineTest {
         BlogPost post = new BlogPost(null, "Title", "Valid Content", null, null, null);
 
         ValidationStep<BlogPost> lengthValidator = new LengthValidator<>(BlogPost::getContent, "content", 5, 20);
-        ValidationStep<BlogPost> phoneNumberForbiddenValidator = new PhoneNumberForbiddenValidator<>(BlogPost::getContent, "content");
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+        ValidationStep<BlogPost> phoneNumberForbiddenValidator = factory.createValidationStep(ValidationStepType.PHONE_NUMBER_FORBIDDEN_VALIDATION, BlogPost::getContent, null, "content", null);
 
         ValidationPipeline<BlogPost> pipeline = new ValidationPipelineBuilder<BlogPost>()
                 .addStep(lengthValidator)
@@ -66,7 +69,8 @@ class ValidationPipelineTest {
 
         String fieldName = "content";
         ValidationStep<BlogPost> lengthValidator = new LengthValidator<>(BlogPost::getContent, fieldName, 5, 50);
-        ValidationStep<BlogPost> phoneNumberForbiddenValidator = new PhoneNumberForbiddenValidator<>(BlogPost::getContent, fieldName);
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+        ValidationStep<BlogPost> phoneNumberForbiddenValidator = factory.createValidationStep(ValidationStepType.PHONE_NUMBER_FORBIDDEN_VALIDATION, BlogPost::getContent, null, "content", null);
 
         ValidationPipeline<BlogPost> pipeline = new ValidationPipelineBuilder<BlogPost>()
                 .addStep(lengthValidator)

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -56,7 +56,7 @@ class ValidationServiceTest {
     }
 
     @Test
-    void givenIContent_whenServiceValidates_thenValidationResultIsCreatedWithRightValues() {
+    void givenContent_whenServiceValidates_thenValidationResultIsCreatedWithRightValues() {
         BlogPostValidationRequest blogPostValidationRequest = new BlogPostValidationRequest(5, 100, 20, 500,
                 new BlogPost(UUID.randomUUID(), "Valid Title", "This is a valid content for the blog post.",
                         Instant.now(), Instant.now(), UUID.randomUUID()));

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -3,6 +3,7 @@ package com.dehold.contentmanager.validation.step;
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.model.ForbiddenWords;
 import com.dehold.contentmanager.validation.model.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,7 @@ class ForbiddenWordValidatorTest {
     @Mock
     ForbiddenWordsService forbiddenWordsService;
 
-    @InjectMocks
-    ForbiddenWordValidator<BlogPost> cut;
+    ValidationStep<BlogPost> cut;
 
     ForbiddenWords defaultForbiddenWords = new ForbiddenWords(null, null, "Default Forbidden Words", "any", "any",
             new LinkedHashSet<>(Arrays.asList("badword1", "badword2")));
@@ -50,7 +50,13 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(
+                ValidationStepType.FORBIDDEN_WORD_VALIDATION,
+                getter,
+                null,
+                fieldThatShouldBeValidated,
+                UUID.randomUUID()
+        );
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -193,9 +199,9 @@ class ForbiddenWordValidatorTest {
 
         ValidationResult result = cut.validate(blogPost);
 
-        String expected = cut.errorMessage("content", List.of("badword1"));
+/*        String expected = cut.errorMessage("content", List.of("badword1"));
         String actual = result.getErrors().getFirst().message();
-        assertEquals(expected, actual);
+        assertEquals(expected, actual);*/
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -74,7 +74,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -92,7 +93,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -110,7 +112,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -130,7 +133,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -151,7 +155,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -170,7 +175,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -191,7 +197,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -212,7 +219,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();
@@ -232,7 +240,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createForbiddenWordValidator(getter, fieldThatShouldBeValidated, UUID.randomUUID());
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+                null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
         String contentType = BlogPost.class.getSimpleName().toLowerCase();

--- a/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ForbiddenWordValidatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -197,7 +198,8 @@ class ForbiddenWordValidatorTest {
         Function<BlogPost, String> getter = BlogPost::getContent;
         ValidationStepFactory factory = new ValidationStepFactory(forbiddenWordsService);
         String fieldThatShouldBeValidated = "content";
-        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION, getter,
+        cut = factory.createValidationStep(ValidationStepType.FORBIDDEN_WORD_VALIDATION,
+                getter,
                 null, fieldThatShouldBeValidated, UUID.randomUUID());
 
         List<ForbiddenWords> forbiddenWordsList = List.of(defaultForbiddenWords, customForbiddenWords);
@@ -206,9 +208,10 @@ class ForbiddenWordValidatorTest {
 
         ValidationResult result = cut.validate(blogPost);
 
-/*        String expected = cut.errorMessage("content", List.of("badword1"));
+        ForbiddenWordValidator<BlogPost> castedCut = (ForbiddenWordValidator<BlogPost>) cut;
+        String expected = castedCut.errorMessage("content", List.of("badword1"));
         String actual = result.getErrors().getFirst().message();
-        assertEquals(expected, actual);*/
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/step/ValidationStepFactoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/step/ValidationStepFactoryTest.java
@@ -1,0 +1,64 @@
+package com.dehold.contentmanager.validation.step;
+
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationStepFactoryTest {
+
+    @Test
+    void givenValidationStepTypeLengthValidation_whenCreateValidationStep_thenReturnLengthValidator() {
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+
+        ValidationStep<?> step = factory.createValidationStep(
+                ValidationStepType.LENGTH_VALIDATION,
+                content -> "test",
+                Map.of("minLength", "5", "maxLength", "10"),
+                "testField",
+                UUID.randomUUID()
+        );
+
+        assertInstanceOf(LengthValidator.class, step);
+        assertEquals("testField", step.getFieldName());
+        LengthValidator<?> lengthValidator = (LengthValidator<?>) step;
+        assertEquals(5, lengthValidator.getMinLength());
+        assertEquals(10, lengthValidator.getMaxLength());
+    }
+
+    @Test
+    void givenValidationStepTypeForbiddenWordValidation_whenCreateValidationStep_thenReturnForbiddenWordValidator() {
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+
+        ValidationStep<?> step = factory.createValidationStep(
+                ValidationStepType.FORBIDDEN_WORD_VALIDATION,
+                content -> "test",
+                Map.of(),
+                "testField",
+                UUID.randomUUID()
+        );
+
+        assertInstanceOf(ForbiddenWordValidator.class, step);
+        assertEquals("testField", step.getFieldName());
+    }
+
+    @Test
+    void givenValidationStepTypePhoneNumberForbiddenValidation_whenCreateValidationStep_thenReturnPhoneNumberForbiddenValidator() {
+        ValidationStepFactory factory = new ValidationStepFactory(null);
+
+        ValidationStep<?> step = factory.createValidationStep(
+                ValidationStepType.PHONE_NUMBER_FORBIDDEN_VALIDATION,
+                content -> "test",
+                Map.of(),
+                "testField",
+                UUID.randomUUID()
+        );
+
+        assertInstanceOf(PhoneNumberForbiddenValidator.class, step);
+        assertEquals("testField", step.getFieldName());
+    }
+
+}


### PR DESCRIPTION
Closes #38 

This PR introduces a streamlined way to instantiate `ValidationSteps` via a factory:

```java
public <T extends Content> ValidationStep<T> createValidationStep(ValidationStepType type,
                                                                     Function<T, String> fieldExtractor, Map<String,
                    String> params, String fieldName, UUID userId) 
```