### PR TITLE
ValidationPipeline Storage

### DIFF
--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
@@ -1,0 +1,5 @@
+package com.dehold.contentmanager.validation.model;
+
+public class ValidationPipelineModel {
+
+}

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
@@ -1,5 +1,16 @@
 package com.dehold.contentmanager.validation.model;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
 public class ValidationPipelineModel {
+    private UUID id;
+    private UUID userId;
+    private String contentType;
+    private boolean isActive;
+    private List<ValidationStepModel> steps;
+    private Instant createdAt;
 
 }
+

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
@@ -12,5 +12,57 @@ public class ValidationPipelineModel {
     private List<ValidationStepModel> steps;
     private Instant createdAt;
 
+    public ValidationPipelineModel(UUID id, UUID userId, String contentType, boolean isActive, List<ValidationStepModel> steps, Instant createdAt) {
+        this.id = id;
+        this.userId = userId;
+        this.contentType = contentType;
+        this.isActive = isActive;
+        this.steps = steps;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    public void setActive(boolean active) {
+        isActive = active;
+    }
+
+    public List<ValidationStepModel> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<ValidationStepModel> steps) {
+        this.steps = steps;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
 }
 

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
@@ -26,6 +26,10 @@ public class ValidationPipelineModel {
         return id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
     public UUID getUserId() {
         return userId;
     }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationPipelineModel.java
@@ -7,16 +7,17 @@ import java.util.UUID;
 public class ValidationPipelineModel {
     private UUID id;
     private UUID userId;
+    private String description;
     private String contentType;
-    private boolean isActive;
     private List<ValidationStepModel> steps;
     private Instant createdAt;
 
-    public ValidationPipelineModel(UUID id, UUID userId, String contentType, boolean isActive, List<ValidationStepModel> steps, Instant createdAt) {
+    public ValidationPipelineModel(UUID id, UUID userId, String description, String contentType,
+                                   List<ValidationStepModel> steps, Instant createdAt) {
         this.id = id;
         this.userId = userId;
+        this.description = description;
         this.contentType = contentType;
-        this.isActive = isActive;
         this.steps = steps;
         this.createdAt = createdAt;
     }
@@ -41,12 +42,12 @@ public class ValidationPipelineModel {
         this.contentType = contentType;
     }
 
-    public boolean isActive() {
-        return isActive;
+    public String getDescription() {
+        return description;
     }
 
-    public void setActive(boolean active) {
-        isActive = active;
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public List<ValidationStepModel> getSteps() {

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
@@ -8,17 +8,15 @@ public class ValidationStepModel {
     private UUID pipelineId;
     private ValidationStepType stepType;
     private String fieldName;
-    private int stepOrder;
     private Map<String, String> parameters;
     private boolean isEnabled;
 
 
-    public ValidationStepModel(UUID id, UUID pipelineId, ValidationStepType stepType, String fieldName, int stepOrder, Map<String, String> parameters, boolean isEnabled) {
+    public ValidationStepModel(UUID id, UUID pipelineId, ValidationStepType stepType, String fieldName, Map<String, String> parameters, boolean isEnabled) {
         this.id = id;
         this.pipelineId = pipelineId;
         this.stepType = stepType;
         this.fieldName = fieldName;
-        this.stepOrder = stepOrder;
         this.parameters = parameters;
         this.isEnabled = isEnabled;
     }
@@ -37,14 +35,6 @@ public class ValidationStepModel {
 
     public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;
-    }
-
-    public int getStepOrder() {
-        return stepOrder;
-    }
-
-    public void setStepOrder(int stepOrder) {
-        this.stepOrder = stepOrder;
     }
 
     public String getFieldName() {

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
@@ -1,6 +1,14 @@
 package com.dehold.contentmanager.validation.model;
 
-public class ValidationStepModel {
-    ValidationStepType validationStepType;
+import java.util.Map;
+import java.util.UUID;
 
+public class ValidationStepModel {
+    private UUID id;
+    private UUID pipelineId;
+    private ValidationStepType stepType;
+    private String fieldName;
+    private int stepOrder;
+    private Map<String, String> parameters;
+    private boolean isEnabled;
 }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
@@ -11,4 +11,67 @@ public class ValidationStepModel {
     private int stepOrder;
     private Map<String, String> parameters;
     private boolean isEnabled;
+
+
+    public ValidationStepModel(UUID id, UUID pipelineId, ValidationStepType stepType, String fieldName, int stepOrder, Map<String, String> parameters, boolean isEnabled) {
+        this.id = id;
+        this.pipelineId = pipelineId;
+        this.stepType = stepType;
+        this.fieldName = fieldName;
+        this.stepOrder = stepOrder;
+        this.parameters = parameters;
+        this.isEnabled = isEnabled;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public int getStepOrder() {
+        return stepOrder;
+    }
+
+    public void setStepOrder(int stepOrder) {
+        this.stepOrder = stepOrder;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public ValidationStepType getStepType() {
+        return stepType;
+    }
+
+    public void setStepType(ValidationStepType stepType) {
+        this.stepType = stepType;
+    }
+
+    public UUID getPipelineId() {
+        return pipelineId;
+    }
+
+    public void setPipelineId(UUID pipelineId) {
+        this.pipelineId = pipelineId;
+    }
+
+    public UUID getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
@@ -1,0 +1,6 @@
+package com.dehold.contentmanager.validation.model;
+
+public class ValidationStepModel {
+    ValidationStepType validationStepType;
+
+}

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepType.java
@@ -1,0 +1,7 @@
+package com.dehold.contentmanager.validation.model;
+
+public enum ValidationStepType {
+    FORBIDDEN_WORDS_VALIDATION,
+    LENGTH_VALIDATION,
+    PHONE_NUMBER_VALIDATION
+}

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -1,0 +1,200 @@
+package com.dehold.contentmanager.validation.repository;
+
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.model.ValidationStepModel;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.*;
+
+@Repository
+public class ValidationPipelineRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+    private final ValidationPipelineRowMapper VALIDATION_PIPELINE_ROW_MAPPER = new ValidationPipelineRowMapper();
+    private final ValidationStepRowMapper VALIDATION_STEP_ROW_MAPPER = new ValidationStepRowMapper();
+
+    public ValidationPipelineRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void save(ValidationPipelineModel pipeline) {
+        Optional<ValidationPipelineModel> existing = findById(pipeline.getId());
+        if (existing.isPresent()) {
+            update(pipeline);
+        } else {
+            insert(pipeline);
+        }
+    }
+
+    private void insert(ValidationPipelineModel pipeline) {
+        if (pipeline.getId() == null) {
+            pipeline.setId(UUID.randomUUID());
+        }
+        if (pipeline.getCreatedAt() == null) {
+            pipeline.setCreatedAt(Instant.now());
+        }
+
+        jdbcTemplate.update(
+                "INSERT INTO validation_pipeline (id, user_id, description, content_type, created_at) VALUES (?, ?, ?, ?, ?)",
+                pipeline.getId(),
+                pipeline.getUserId(),
+                pipeline.getDescription(),
+                pipeline.getContentType(),
+                pipeline.getCreatedAt()
+        );
+
+        if (pipeline.getSteps() != null) {
+            for (ValidationStepModel step : pipeline.getSteps()) {
+                insertValidationStep(step, pipeline.getId());
+            }
+        }
+    }
+
+    private void update(ValidationPipelineModel pipeline) {
+        jdbcTemplate.update(
+                "UPDATE validation_pipeline SET user_id = ?, description = ?, content_type = ? WHERE id = ?",
+                pipeline.getUserId(),
+                pipeline.getDescription(),
+                pipeline.getContentType(),
+                pipeline.getId()
+        );
+
+        jdbcTemplate.update("DELETE FROM validation_step WHERE pipeline_id = ?", pipeline.getId());
+        if (pipeline.getSteps() != null) {
+            for (ValidationStepModel step : pipeline.getSteps()) {
+                insertValidationStep(step, pipeline.getId());
+            }
+        }
+    }
+
+    private void insertValidationStep(ValidationStepModel step, UUID pipelineId) {
+        try {
+            String parametersJson = objectMapper.writeValueAsString(step.getParameters());
+            jdbcTemplate.update(
+                    "INSERT INTO validation_step (id, pipeline_id, step_type, field_name, parameters, is_enabled) VALUES (?, ?, ?, ?, ?, ?)",
+                    step.getId() != null ? step.getId() : UUID.randomUUID(),
+                    pipelineId,
+                    step.getStepType().name(),
+                    step.getFieldName(),
+                    parametersJson,
+                    step.isEnabled()
+            );
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize validation step parameters", e);
+        }
+    }
+
+    public List<ValidationPipelineModel> findAll() {
+        List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
+                "SELECT * FROM validation_pipeline ORDER BY created_at",
+                VALIDATION_PIPELINE_ROW_MAPPER
+        );
+
+        for (ValidationPipelineModel pipeline : pipelines) {
+            List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
+            pipeline.setSteps(steps);
+        }
+
+        return pipelines;
+    }
+
+    public Optional<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {
+        List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
+                "SELECT * FROM validation_pipeline WHERE user_id = ? AND content_type = ?",
+                VALIDATION_PIPELINE_ROW_MAPPER,
+                userId,
+                contentType
+        );
+
+        if (pipelines.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ValidationPipelineModel pipeline = pipelines.getFirst();
+        List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
+        pipeline.setSteps(steps);
+
+        return Optional.of(pipeline);
+    }
+
+    public void deleteById(UUID id) {
+        jdbcTemplate.update("DELETE FROM validation_step WHERE pipeline_id = ?", id);
+        jdbcTemplate.update("DELETE FROM validation_pipeline WHERE id = ?", id);
+    }
+
+    private Optional<ValidationPipelineModel> findById(UUID id) {
+        List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
+                "SELECT * FROM validation_pipeline WHERE id = ?",
+                VALIDATION_PIPELINE_ROW_MAPPER,
+                id
+        );
+
+        if (pipelines.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ValidationPipelineModel pipeline = pipelines.get(0);
+        List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
+        pipeline.setSteps(steps);
+
+        return Optional.of(pipeline);
+    }
+
+    private List<ValidationStepModel> loadStepsForPipeline(UUID pipelineId) {
+        return jdbcTemplate.query(
+                "SELECT * FROM validation_step WHERE pipeline_id = ? ORDER BY id",
+                VALIDATION_STEP_ROW_MAPPER,
+                pipelineId
+        );
+    }
+
+    private class ValidationPipelineRowMapper implements RowMapper<ValidationPipelineModel> {
+        @Override
+        public ValidationPipelineModel mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ValidationPipelineModel(
+                    UUID.fromString(rs.getString("id")),
+                    UUID.fromString(rs.getString("user_id")),
+                    rs.getString("description"),
+                    rs.getString("content_type"),
+                    new ArrayList<>(), // Steps will be loaded separately
+                    rs.getTimestamp("created_at").toInstant()
+            );
+        }
+    }
+
+    private class ValidationStepRowMapper implements RowMapper<ValidationStepModel> {
+        @Override
+        public ValidationStepModel mapRow(ResultSet rs, int rowNum) throws SQLException {
+            try {
+                String parametersJson = rs.getString("parameters");
+                Map<String, String> parameters = new HashMap<>();
+
+                if (parametersJson != null && !parametersJson.trim().isEmpty()) {
+                    parameters = objectMapper.readValue(parametersJson, new TypeReference<Map<String, String>>() {});
+                }
+
+                return new ValidationStepModel(
+                        UUID.fromString(rs.getString("id")),
+                        UUID.fromString(rs.getString("pipeline_id")),
+                        ValidationStepType.valueOf(rs.getString("step_type")),
+                        rs.getString("field_name"),
+                        parameters,
+                        rs.getBoolean("is_enabled")
+                );
+            } catch (JsonProcessingException e) {
+                throw new SQLException("Failed to deserialize validation step parameters", e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -181,7 +181,9 @@ public class ValidationPipelineRepository {
                 Map<String, String> parameters = new HashMap<>();
 
                 if (parametersJson != null && !parametersJson.trim().isEmpty()) {
-                    parameters = objectMapper.readValue(parametersJson, new TypeReference<Map<String, String>>() {});
+                    String cleanJson = stripRedundantQuotes(parametersJson);
+                    parameters = objectMapper.readValue(cleanJson, new TypeReference<Map<String, String>>() {
+                    });
                 }
 
                 return new ValidationStepModel(
@@ -193,8 +195,17 @@ public class ValidationPipelineRepository {
                         rs.getBoolean("is_enabled")
                 );
             } catch (JsonProcessingException e) {
-                throw new SQLException("Failed to deserialize validation step parameters", e);
+                throw new SQLException("Failed to deserialize validation step parameters: " + e.getMessage(), e);
             }
+        }
+
+        private static String stripRedundantQuotes(String parametersJson) {
+            String cleanJson = parametersJson;
+            if (parametersJson.startsWith("\"") && parametersJson.endsWith("\"")) {
+                cleanJson = parametersJson.substring(1, parametersJson.length() - 1)
+                        .replace("\\\"", "\"");
+            }
+            return cleanJson;
         }
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationResultRepository.java
@@ -43,9 +43,8 @@ public class ValidationResultRepository {
     }
 
     public List<ValidationResult> findByUserId(UUID id) {
-        List<ValidationResult> result = jdbcTemplate.query("SELECT * FROM validation_result WHERE user_id = ?", this::mapRowToValidationResult,
+        return jdbcTemplate.query("SELECT * FROM validation_result WHERE user_id = ?", this::mapRowToValidationResult,
                 id);
-        return result;
     }
 
     private ValidationResult mapRowToValidationResult(ResultSet rs, int rowNum) throws SQLException {

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -19,18 +19,6 @@ public class ValidationStepFactory {
         this.forbiddenWordsService = forbiddenWordsService;
     }
 
-    public <T extends Content> ValidationStep<T> createValidationStepFromModel(ValidationStepModel stepModel,
-                                                                               Function<T, String> fieldExtractor) {
-        Map<String, String> params = stepModel.getParameters();
-        return createValidationStep(
-                stepModel.getStepType(),
-                fieldExtractor,
-                params,
-                stepModel.getFieldName(),
-                UUID.fromString(params.get("userId"))
-        );
-    }
-
     public <T extends Content> ValidationStep<T> createValidationStep(ValidationStepType type,
                                                                      Function<T, String> fieldExtractor, Map<String,
                     String> params, String fieldName, UUID userId) {

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -1,6 +1,7 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
+import com.dehold.contentmanager.validation.model.ValidationStepModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,18 @@ public class ValidationStepFactory {
 
     public ValidationStepFactory(ForbiddenWordsService forbiddenWordsService) {
         this.forbiddenWordsService = forbiddenWordsService;
+    }
+
+    public <T extends Content> ValidationStep<T> createValidationStepFromModel(ValidationStepModel stepModel,
+                                                                               Function<T, String> fieldExtractor) {
+        Map<String, String> params = stepModel.getParameters();
+        return createValidationStep(
+                stepModel.getStepType(),
+                fieldExtractor,
+                params,
+                stepModel.getFieldName(),
+                UUID.fromString(params.get("userId"))
+        );
     }
 
     public <T extends Content> ValidationStep<T> createValidationStep(ValidationStepType type,

--- a/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
+++ b/src/main/java/com/dehold/contentmanager/validation/step/ValidationStepFactory.java
@@ -1,7 +1,6 @@
 package com.dehold.contentmanager.validation.step;
 
 import com.dehold.contentmanager.content.Content;
-import com.dehold.contentmanager.validation.model.ValidationStepModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.service.ForbiddenWordsService;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -55,3 +55,22 @@ CREATE TABLE IF NOT EXISTS forbidden_words (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE validation_pipeline (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    description VARCHAR(500),
+    content_type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, content_type)
+);
+
+CREATE TABLE validation_step (
+    id UUID PRIMARY KEY,
+    pipeline_id UUID,
+    step_type VARCHAR(50) NOT NULL,
+    field_name VARCHAR(100) NOT NULL,
+    step_order INTEGER NOT NULL,
+    parameters JSON,
+    is_enabled BOOLEAN DEFAULT true
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -70,7 +70,6 @@ CREATE TABLE validation_step (
     pipeline_id UUID,
     step_type VARCHAR(50) NOT NULL,
     field_name VARCHAR(100) NOT NULL,
-    step_order INTEGER NOT NULL,
     parameters JSON,
     is_enabled BOOLEAN DEFAULT true
 );

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -189,4 +189,44 @@ class ValidationPipelineRepositoryTest {
         assertEquals(forbiddenParams, savedForbiddenStep.getParameters());
         assertFalse(savedForbiddenStep.isEnabled());
     }
+
+    @Test
+    void givenNoPipelines_whenFindAll_thenReturnsEmptyList() {
+        List<ValidationPipelineModel> result = cut.findAll();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void givenMultiplePipelines_whenFindAll_thenReturnsAllPipelines() {
+        UUID userId1 = UUID.randomUUID();
+        UUID userId2 = UUID.randomUUID();
+
+        ValidationPipelineModel pipeline1 = new ValidationPipelineModel(
+                UUID.randomUUID(),
+                userId1,
+                "Pipeline 1",
+                "blogpost",
+                new ArrayList<>(),
+                Instant.now().minusSeconds(100)
+        );
+
+        ValidationPipelineModel pipeline2 = new ValidationPipelineModel(
+                UUID.randomUUID(),
+                userId2,
+                "Pipeline 2",
+                "supportrequest",
+                new ArrayList<>(),
+                Instant.now()
+        );
+
+        cut.save(pipeline1);
+        cut.save(pipeline2);
+
+        List<ValidationPipelineModel> result = cut.findAll();
+
+        assertEquals(2, result.size());
+        assertEquals("Pipeline 1", result.get(0).getDescription()); // Should be ordered by created_at
+        assertEquals("Pipeline 2", result.get(1).getDescription());
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -229,4 +229,32 @@ class ValidationPipelineRepositoryTest {
         assertEquals("Pipeline 1", result.get(0).getDescription()); // Should be ordered by created_at
         assertEquals("Pipeline 2", result.get(1).getDescription());
     }
+
+    @Test
+    void givenPipelineExists_whenFindByUserIdAndContentType_thenReturnsPipeline() {
+        UUID userId = UUID.randomUUID();
+        String contentType = "blogpost";
+
+        ValidationPipelineModel pipeline = new ValidationPipelineModel(
+                UUID.randomUUID(),
+                userId,
+                "Test pipeline",
+                contentType,
+                new ArrayList<>(),
+                Instant.now()
+        );
+        cut.save(pipeline);
+
+        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+
+        assertTrue(result.isPresent());
+        assertEquals("Test pipeline", result.get().getDescription());
+    }
+
+    @Test
+    void givenPipelineDoesNotExist_whenFindByUserIdAndContentType_thenReturnsEmpty() {
+        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(UUID.randomUUID(), "nonexistent");
+
+        assertFalse(result.isPresent());
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -231,16 +231,42 @@ class ValidationPipelineRepositoryTest {
     }
 
     @Test
-    void givenPipelineExists_whenFindByUserIdAndContentType_thenReturnsPipeline() {
+    void givenPipelineExists_whenFindByUserIdAndContentType_thenReturnsPipelineAndSteps() {
         UUID userId = UUID.randomUUID();
         String contentType = "blogpost";
+        UUID pipelineId = UUID.randomUUID();
+
+        Map<String, String> lengthParams = new HashMap<>();
+        lengthParams.put("minLength", "5");
+        lengthParams.put("maxLength", "200");
+
+        Map<String, String> forbiddenParams = new HashMap<>();
+        forbiddenParams.put("words", "test,example");
+
+        ValidationStepModel lengthStep = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.LENGTH_VALIDATION,
+                "title",
+                lengthParams,
+                true
+        );
+
+        ValidationStepModel forbiddenStep = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.FORBIDDEN_WORD_VALIDATION,
+                "content",
+                forbiddenParams,
+                true
+        );
 
         ValidationPipelineModel pipeline = new ValidationPipelineModel(
-                UUID.randomUUID(),
+                pipelineId,
                 userId,
                 "Test pipeline",
                 contentType,
-                new ArrayList<>(),
+                List.of(lengthStep, forbiddenStep),
                 Instant.now()
         );
         cut.save(pipeline);
@@ -248,7 +274,25 @@ class ValidationPipelineRepositoryTest {
         Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
 
         assertTrue(result.isPresent());
-        assertEquals("Test pipeline", result.get().getDescription());
+        ValidationPipelineModel foundPipeline = result.get();
+        assertEquals("Test pipeline", foundPipeline.getDescription());
+        assertEquals(2, foundPipeline.getSteps().size());
+
+        ValidationStepModel foundLengthStep = foundPipeline.getSteps().stream()
+                .filter(s -> s.getStepType() == ValidationStepType.LENGTH_VALIDATION)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("title", foundLengthStep.getFieldName());
+        assertEquals(lengthParams, foundLengthStep.getParameters());
+        assertTrue(foundLengthStep.isEnabled());
+
+        ValidationStepModel foundForbiddenStep = foundPipeline.getSteps().stream()
+                .filter(s -> s.getStepType() == ValidationStepType.FORBIDDEN_WORD_VALIDATION)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("content", foundForbiddenStep.getFieldName());
+        assertEquals(forbiddenParams, foundForbiddenStep.getParameters());
+        assertTrue(foundForbiddenStep.isEnabled());
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -121,6 +121,7 @@ class ValidationPipelineRepositoryTest {
         assertTrue(result.isPresent());
 
         ValidationPipelineModel savedPipeline = result.get();
+        assertEquals(pipelineId, savedPipeline.getId());
         assertEquals("Updated description", savedPipeline.getDescription());
         assertEquals(1, savedPipeline.getSteps().size());
         assertEquals("title", savedPipeline.getSteps().getFirst().getFieldName());

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -257,4 +257,45 @@ class ValidationPipelineRepositoryTest {
 
         assertFalse(result.isPresent());
     }
+
+    @Test
+    void givenPipelineExists_whenDeleteById_thenRemovesPipelineAndSteps() {
+        UUID pipelineId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("minLength", "10");
+
+        ValidationStepModel step = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.LENGTH_VALIDATION,
+                "content",
+                parameters,
+                true
+        );
+
+        ValidationPipelineModel pipeline = new ValidationPipelineModel(
+                pipelineId,
+                userId,
+                "Test pipeline",
+                "blogpost",
+                List.of(step),
+                Instant.now()
+        );
+        cut.save(pipeline);
+
+        assertTrue(cut.findByUserIdAndContentType(userId, "blogpost").isPresent());
+
+        cut.deleteById(pipelineId);
+
+        assertFalse(cut.findByUserIdAndContentType(userId, "blogpost").isPresent());
+
+        int stepCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM validation_step WHERE pipeline_id = ?",
+                Integer.class,
+                pipelineId
+        );
+        assertEquals(0, stepCount);
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -1,0 +1,192 @@
+package com.dehold.contentmanager.validation.repository;
+
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.model.ValidationStepModel;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ValidationPipelineRepositoryTest {
+
+    @Autowired
+    ValidationPipelineRepository cut;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM validation_step");
+        jdbcTemplate.update("DELETE FROM validation_pipeline");
+    }
+
+    @Test
+    void givenValidationPipelineDoesNotExist_whenSave_thenInsertsNewPipeline() {
+        UUID pipelineId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID stepId = UUID.randomUUID();
+        String contentType = "blogpost";
+        String description = "Test pipeline";
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("minLength", "10");
+        parameters.put("maxLength", "100");
+
+        ValidationStepModel step = new ValidationStepModel(
+                stepId,
+                pipelineId,
+                ValidationStepType.LENGTH_VALIDATION,
+                "content",
+                parameters,
+                true
+        );
+
+        ValidationPipelineModel pipeline = new ValidationPipelineModel(
+                pipelineId,
+                userId,
+                description,
+                contentType,
+                List.of(step),
+                Instant.now()
+        );
+
+        cut.save(pipeline);
+
+        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        assertTrue(result.isPresent());
+
+        ValidationPipelineModel savedPipeline = result.get();
+        assertEquals(pipelineId, savedPipeline.getId());
+        assertEquals(userId, savedPipeline.getUserId());
+        assertEquals(description, savedPipeline.getDescription());
+        assertEquals(contentType, savedPipeline.getContentType());
+        assertNotNull(savedPipeline.getCreatedAt());
+
+        assertEquals(1, savedPipeline.getSteps().size());
+        ValidationStepModel savedStep = savedPipeline.getSteps().getFirst();
+        assertEquals(ValidationStepType.LENGTH_VALIDATION, savedStep.getStepType());
+        assertEquals("content", savedStep.getFieldName());
+        assertEquals(parameters, savedStep.getParameters());
+        assertTrue(savedStep.isEnabled());
+    }
+
+    @Test
+    void givenPipelineExists_whenSave_thenUpdatesExistingPipeline() {
+        UUID pipelineId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String contentType = "blogpost";
+
+        ValidationPipelineModel initialPipeline = new ValidationPipelineModel(
+                pipelineId,
+                userId,
+                "Initial description",
+                contentType,
+                new ArrayList<>(),
+                Instant.now()
+        );
+        cut.save(initialPipeline);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("minLength", "5");
+
+        ValidationStepModel newStep = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.LENGTH_VALIDATION,
+                "title",
+                parameters,
+                true
+        );
+
+        ValidationPipelineModel updatedPipeline = new ValidationPipelineModel(
+                pipelineId,
+                userId,
+                "Updated description",
+                contentType,
+                List.of(newStep),
+                null // createdAt should be preserved
+        );
+        cut.save(updatedPipeline);
+
+        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        assertTrue(result.isPresent());
+
+        ValidationPipelineModel savedPipeline = result.get();
+        assertEquals("Updated description", savedPipeline.getDescription());
+        assertEquals(1, savedPipeline.getSteps().size());
+        assertEquals("title", savedPipeline.getSteps().getFirst().getFieldName());
+    }
+
+    @Test
+    void givenPipelineWithMultipleSteps_whenSave_thenSavesAllSteps() {
+        UUID pipelineId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Map<String, String> lengthParams = new HashMap<>();
+        lengthParams.put("minLength", "10");
+        lengthParams.put("maxLength", "100");
+
+        Map<String, String> forbiddenParams = new HashMap<>();
+        forbiddenParams.put("words", "spam,badword");
+
+        ValidationStepModel lengthStep = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.LENGTH_VALIDATION,
+                "content",
+                lengthParams,
+                true
+        );
+
+        ValidationStepModel forbiddenStep = new ValidationStepModel(
+                UUID.randomUUID(),
+                pipelineId,
+                ValidationStepType.FORBIDDEN_WORD_VALIDATION,
+                "title",
+                forbiddenParams,
+                false
+        );
+
+        ValidationPipelineModel pipeline = new ValidationPipelineModel(
+                pipelineId,
+                userId,
+                "Multi-step pipeline",
+                "blogpost",
+                List.of(lengthStep, forbiddenStep),
+                Instant.now()
+        );
+
+        cut.save(pipeline);
+
+        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, "blogpost");
+        assertTrue(result.isPresent());
+
+        ValidationPipelineModel savedPipeline = result.get();
+        assertEquals(2, savedPipeline.getSteps().size());
+
+        ValidationStepModel savedLengthStep = savedPipeline.getSteps().stream()
+                .filter(s -> s.getStepType() == ValidationStepType.LENGTH_VALIDATION)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("content", savedLengthStep.getFieldName());
+        assertEquals(lengthParams, savedLengthStep.getParameters());
+        assertTrue(savedLengthStep.isEnabled());
+
+        ValidationStepModel savedForbiddenStep = savedPipeline.getSteps().stream()
+                .filter(s -> s.getStepType() == ValidationStepType.FORBIDDEN_WORD_VALIDATION)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("title", savedForbiddenStep.getFieldName());
+        assertEquals(forbiddenParams, savedForbiddenStep.getParameters());
+        assertFalse(savedForbiddenStep.isEnabled());
+    }
+}


### PR DESCRIPTION
Closes #40 

This PR allows for persisting validation pipelines with the following schema:

```sql
CREATE TABLE validation_pipeline (
    id UUID PRIMARY KEY,
    user_id UUID NOT NULL,
    description VARCHAR(500),
    content_type VARCHAR(50) NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    UNIQUE(user_id, content_type)
);

CREATE TABLE validation_step (
    id UUID PRIMARY KEY,
    pipeline_id UUID,
    step_type VARCHAR(50) NOT NULL,
    field_name VARCHAR(100) NOT NULL,
    parameters JSON,
    is_enabled BOOLEAN DEFAULT true
);
```