### PR TITLE
Introduce Validation Pipeline API

### DIFF
--- a/src/main/java/com/dehold/contentmanager/user/service/UserService.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.dehold.contentmanager.user.service;
 import com.dehold.contentmanager.user.model.User;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 
 import java.util.UUID;
 
@@ -15,4 +16,6 @@ public interface UserService {
     User updateUser(UUID id, UpdateUserRequest dto);
 
     void deleteUser(UUID id);
+
+    ValidationPipelineModel getValidationPipelineRepositoryByUserIdAndContentType(UUID userId, String contentType);
 }

--- a/src/main/java/com/dehold/contentmanager/user/service/UserService.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserService.java
@@ -17,5 +17,5 @@ public interface UserService {
 
     void deleteUser(UUID id);
 
-    ValidationPipelineModel getValidationPipelineRepositoryByUserIdAndContentType(UUID userId, String contentType);
+    ValidationPipelineModel getValidationPipelineByUserIdAndContentType(UUID userId, String contentType);
 }

--- a/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService {
         userRepository.deleteUser(id);
     }
 
-    public ValidationPipelineModel getValidationPipelineRepositoryByUserIdAndContentType(UUID userId,
+    public ValidationPipelineModel getValidationPipelineByUserIdAndContentType(UUID userId,
                                                                                        String contentType) {
         getUser(userId); // Ensure user exists
         return validationPipelineService.findByUserIdAndContentType(userId, contentType);

--- a/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
@@ -5,6 +5,8 @@ import com.dehold.contentmanager.user.model.User;
 import com.dehold.contentmanager.user.repository.UserRepository;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.service.ValidationPipelineService;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -15,7 +17,10 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 
-    public UserServiceImpl(UserRepository userRepository) {
+    private final ValidationPipelineService validationPipelineService;
+
+    public UserServiceImpl(UserRepository userRepository, ValidationPipelineService validationPipelineService) {
+        this.validationPipelineService = validationPipelineService;
         this.userRepository = userRepository;
     }
 
@@ -55,5 +60,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public void deleteUser(UUID id) {
         userRepository.deleteUser(id);
+    }
+
+    public ValidationPipelineModel getValidationPipelineRepositoryByUserIdAndContentType(UUID userId,
+                                                                                       String contentType) {
+        getUser(userId); // Ensure user exists
+        return validationPipelineService.findByUserIdAndContentType(userId, contentType);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ValidationStepModel.java
@@ -64,4 +64,8 @@ public class ValidationStepModel {
     public UUID getId() {
         return id;
     }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -28,7 +28,7 @@ public class ValidationPipelineRepository {
         this.objectMapper = new ObjectMapper();
     }
 
-    public ValidationPipelineModel save(ValidationPipelineModel pipeline) {
+    public void save(ValidationPipelineModel pipeline) {
         Optional<ValidationPipelineModel> existing = findById(pipeline.getId());
         if (existing.isPresent()) {
             update(pipeline);
@@ -107,6 +107,24 @@ public class ValidationPipelineRepository {
         }
 
         return pipelines;
+    }
+
+    public Optional<ValidationPipelineModel> findByUserId(UUID userId) {
+        List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
+                "SELECT * FROM validation_pipeline WHERE user_id = ?",
+                VALIDATION_PIPELINE_ROW_MAPPER,
+                userId
+        );
+
+        if (pipelines.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ValidationPipelineModel pipeline = pipelines.getFirst();
+        List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
+        pipeline.setSteps(steps);
+
+        return Optional.of(pipeline);
     }
 
     public Optional<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -56,6 +56,8 @@ public class ValidationPipelineRepository {
 
         if (pipeline.getSteps() != null) {
             for (ValidationStepModel step : pipeline.getSteps()) {
+                step.setId(UUID.randomUUID());
+                step.setPipelineId(pipeline.getId());
                 insertValidationStep(step, pipeline.getId());
             }
         }

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -109,24 +109,6 @@ public class ValidationPipelineRepository {
         return pipelines;
     }
 
-    public Optional<ValidationPipelineModel> findByUserId(UUID userId) {
-        List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
-                "SELECT * FROM validation_pipeline WHERE user_id = ?",
-                VALIDATION_PIPELINE_ROW_MAPPER,
-                userId
-        );
-
-        if (pipelines.isEmpty()) {
-            return Optional.empty();
-        }
-
-        ValidationPipelineModel pipeline = pipelines.getFirst();
-        List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
-        pipeline.setSteps(steps);
-
-        return Optional.of(pipeline);
-    }
-
     public Optional<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {
         List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
                 "SELECT * FROM validation_pipeline WHERE user_id = ? AND content_type = ?",

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -133,7 +133,7 @@ public class ValidationPipelineRepository {
         jdbcTemplate.update("DELETE FROM validation_pipeline WHERE id = ?", id);
     }
 
-    private Optional<ValidationPipelineModel> findById(UUID id) {
+    public Optional<ValidationPipelineModel> findById(UUID id) {
         List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
                 "SELECT * FROM validation_pipeline WHERE id = ?",
                 VALIDATION_PIPELINE_ROW_MAPPER,

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -28,7 +28,7 @@ public class ValidationPipelineRepository {
         this.objectMapper = new ObjectMapper();
     }
 
-    public void save(ValidationPipelineModel pipeline) {
+    public ValidationPipelineModel save(ValidationPipelineModel pipeline) {
         Optional<ValidationPipelineModel> existing = findById(pipeline.getId());
         if (existing.isPresent()) {
             update(pipeline);

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
@@ -1,7 +1,10 @@
 package com.dehold.contentmanager.validation.service;
 
+import com.dehold.contentmanager.exception.EntityNotFoundException;
 import com.dehold.contentmanager.service.IService;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.repository.ValidationPipelineRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,28 +12,42 @@ import java.util.UUID;
 
 @Service
 public class ValidationPipelineService implements IService<ValidationPipelineModel> {
+
+    @Autowired
+    private final ValidationPipelineRepository repository;
+
+    public ValidationPipelineService(ValidationPipelineRepository repository) {
+        this.repository = repository;
+    }
+
     @Override
     public ValidationPipelineModel create(ValidationPipelineModel entity) {
-        return null;
+        repository.save(entity);
+        return entity;
     }
 
     @Override
     public ValidationPipelineModel findById(UUID id) {
-        return null;
+        return null; // Not needed
+    }
+
+    public ValidationPipelineModel findByUserIdAndContentType(UUID userId, String contentType) {
+        return repository.findByUserIdAndContentType(userId, contentType).orElse(null);
     }
 
     @Override
     public List<ValidationPipelineModel> findAll() {
-        return List.of();
+        return repository.findAll();
     }
 
     @Override
     public ValidationPipelineModel update(UUID id, ValidationPipelineModel entity) {
-        return null;
+        repository.save(entity);
+        return entity;
     }
 
     @Override
     public void delete(UUID id) {
-
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
@@ -42,4 +42,9 @@ public class ValidationPipelineService {
     public void delete(UUID id) {
         repository.deleteById(id);
     }
+
+    public ValidationPipelineModel findById(UUID id) {
+        return repository.findById(id).orElseThrow(() -> EntityNotFoundException.of("ValidationPipeline",
+                id.toString()));
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
@@ -1,0 +1,36 @@
+package com.dehold.contentmanager.validation.service;
+
+import com.dehold.contentmanager.service.IService;
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ValidationPipelineService implements IService<ValidationPipelineModel> {
+    @Override
+    public ValidationPipelineModel create(ValidationPipelineModel entity) {
+        return null;
+    }
+
+    @Override
+    public ValidationPipelineModel findById(UUID id) {
+        return null;
+    }
+
+    @Override
+    public List<ValidationPipelineModel> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public ValidationPipelineModel update(UUID id, ValidationPipelineModel entity) {
+        return null;
+    }
+
+    @Override
+    public void delete(UUID id) {
+
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class ValidationPipelineService implements IService<ValidationPipelineModel> {
+public class ValidationPipelineService {
 
     @Autowired
     private final ValidationPipelineRepository repository;
@@ -20,33 +20,25 @@ public class ValidationPipelineService implements IService<ValidationPipelineMod
         this.repository = repository;
     }
 
-    @Override
     public ValidationPipelineModel create(ValidationPipelineModel entity) {
         repository.save(entity);
         return entity;
-    }
-
-    @Override
-    public ValidationPipelineModel findById(UUID id) {
-        return null; // Not needed
     }
 
     public ValidationPipelineModel findByUserIdAndContentType(UUID userId, String contentType) {
         return repository.findByUserIdAndContentType(userId, contentType).orElse(null);
     }
 
-    @Override
+
     public List<ValidationPipelineModel> findAll() {
         return repository.findAll();
     }
 
-    @Override
-    public ValidationPipelineModel update(UUID id, ValidationPipelineModel entity) {
+    public ValidationPipelineModel update(ValidationPipelineModel entity) {
         repository.save(entity);
         return entity;
     }
 
-    @Override
     public void delete(UUID id) {
         repository.deleteById(id);
     }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -29,6 +29,14 @@ public class ValidationPipelineController {
         return new ResponseEntity<>(model, HttpStatus.OK);
     }
 
+    @GetMapping
+    public ResponseEntity<ValidationPipelineModel> getValidationPipelineByUserIdAndContentType(
+            @RequestParam UUID userId,
+            @RequestParam String contentType) {
+        ValidationPipelineModel model = validationPipelineService.findByUserIdAndContentType(userId, contentType);
+        return new ResponseEntity<>(model, HttpStatus.OK);
+    }
+
 
     @PostMapping
     public ResponseEntity<ValidationPipelineModel> createValidationPipeline(@RequestBody ValidationPipelineCreateDto dto) {

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -23,6 +23,12 @@ public class ValidationPipelineController {
         this.validationPipelineService = validationPipelineService;
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<ValidationPipelineModel> getValidationPipeline(@PathVariable UUID id) {
+        ValidationPipelineModel model = validationPipelineService.findById(id);
+        return new ResponseEntity<>(model, HttpStatus.OK);
+    }
+
 
     @PostMapping
     public ResponseEntity<ValidationPipelineModel> createValidationPipeline(@RequestBody ValidationPipelineCreateDto dto) {
@@ -35,6 +41,12 @@ public class ValidationPipelineController {
                                                                             @RequestBody ValidationPipelineUpdateDto dto) {
         ValidationPipelineModel model = validationPipelineService.update(dto.toModel());
         return new ResponseEntity<>(model, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteValidationPipeline(@PathVariable UUID id) {
+        validationPipelineService.delete(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/validation-pipeline")
+@RequestMapping("/api/validation-pipelines")
 public class ValidationPipelineController {
 
     @Autowired

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -1,10 +1,33 @@
 package com.dehold.contentmanager.validation.web;
 
 
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.service.ValidationPipelineService;
+import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/validation-pipeline")
 public class ValidationPipelineController {
+
+    @Autowired
+    private final ValidationPipelineService validationPipelineService;
+
+    public ValidationPipelineController(ValidationPipelineService validationPipelineService) {
+        this.validationPipelineService = validationPipelineService;
+    }
+
+
+    @PostMapping
+    public ResponseEntity<ValidationPipelineModel> createValidationPipeline(@RequestBody ValidationPipelineCreateDto dto) {
+        ValidationPipelineModel model = validationPipelineService.create(dto.toModel());
+        return new ResponseEntity<>(model, HttpStatus.CREATED);
+    }
+
 }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -4,13 +4,13 @@ package com.dehold.contentmanager.validation.web;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.service.ValidationPipelineService;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
+import com.dehold.contentmanager.validation.web.dto.ValidationPipelineUpdateDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/validation-pipeline")
@@ -28,6 +28,13 @@ public class ValidationPipelineController {
     public ResponseEntity<ValidationPipelineModel> createValidationPipeline(@RequestBody ValidationPipelineCreateDto dto) {
         ValidationPipelineModel model = validationPipelineService.create(dto.toModel());
         return new ResponseEntity<>(model, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ValidationPipelineModel> updateValidationPipeline(@PathVariable UUID id,
+                                                                            @RequestBody ValidationPipelineUpdateDto dto) {
+        ValidationPipelineModel model = validationPipelineService.update(dto.toModel());
+        return new ResponseEntity<>(model, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -1,0 +1,10 @@
+package com.dehold.contentmanager.validation.web;
+
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/validation-pipeline")
+public class ValidationPipelineController {
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineCreateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineCreateDto.java
@@ -22,7 +22,7 @@ public class ValidationPipelineCreateDto {
         if (model.getSteps() != null) {
             dto.setSteps(model.getSteps().stream()
                     .map(s ->
-                            new ValidationStepDto(s.getStepType(), s.getFieldName(), s.getParameters(),
+                            new ValidationStepDto(null, s.getStepType(), s.getFieldName(), s.getParameters(),
                                     s.isEnabled())).toList());
         }
         return dto;

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineCreateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineCreateDto.java
@@ -1,0 +1,82 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.model.ValidationStepModel;
+import java.util.stream.Collectors;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toList;
+
+public class ValidationPipelineCreateDto {
+    private UUID userId;
+    private String description;
+    private String contentType;
+    private List<ValidationStepDto> steps;
+
+    public static ValidationPipelineCreateDto fromModel(ValidationPipelineModel model) {
+        ValidationPipelineCreateDto dto = new ValidationPipelineCreateDto();
+        dto.setUserId(model.getUserId());
+        dto.setDescription(model.getDescription());
+        dto.setContentType(model.getContentType());
+        if (model.getSteps() != null) {
+            dto.setSteps(model.getSteps().stream()
+                    .map(s ->
+                            new ValidationStepDto(s.getStepType(), s.getFieldName(), s.getParameters(),
+                                    s.isEnabled())).toList());
+        }
+        return dto;
+    }
+
+    public ValidationPipelineModel toModel() {
+        return new ValidationPipelineModel(
+                null, // id remains null
+                this.getUserId(),
+                this.getDescription(),
+                this.getContentType(),
+                this.getSteps() != null ? this.getSteps().stream()
+                        .map(s -> new ValidationStepModel(
+                                null,
+                                null,
+                                s.getStepType(),
+                                s.getFieldName(),
+                                s.getParameters(),
+                                s.isEnabled()
+                        ))
+                        .toList() : null,
+                null
+        );
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public List<ValidationStepDto> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<ValidationStepDto> steps) {
+        this.steps = steps;
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineDeleteDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineDeleteDto.java
@@ -1,0 +1,15 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import java.util.UUID;
+
+public class ValidationPipelineDeleteDto {
+    private UUID id;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineUpdateDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationPipelineUpdateDto.java
@@ -1,0 +1,95 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.model.ValidationStepModel;
+import java.util.List;
+import java.util.UUID;
+
+public class ValidationPipelineUpdateDto {
+    private UUID id;
+    private UUID userId;
+    private String description;
+    private String contentType;
+    private List<ValidationStepDto> steps;
+
+    public static ValidationPipelineUpdateDto fromModel(ValidationPipelineModel model) {
+        ValidationPipelineUpdateDto dto = new ValidationPipelineUpdateDto();
+        dto.setId(model.getId());
+        dto.setUserId(model.getUserId());
+        dto.setDescription(model.getDescription());
+        dto.setContentType(model.getContentType());
+        if (model.getSteps() != null) {
+            dto.setSteps(model.getSteps().stream()
+                    .map(s -> new ValidationStepDto(
+                            s.getId(),
+                            s.getStepType(),
+                            s.getFieldName(),
+                            s.getParameters(),
+                            s.isEnabled()
+                    ))
+                    .toList());
+        }
+        return dto;
+    }
+
+    public ValidationPipelineModel toModel() {
+        return new ValidationPipelineModel(
+                this.getId(),
+                this.getUserId(),
+                this.getDescription(),
+                this.getContentType(),
+                this.getSteps() != null ? this.getSteps().stream()
+                        .map(s -> new ValidationStepModel(
+                                s.getId(),
+                                this.getId(),
+                                s.getStepType(),
+                                s.getFieldName(),
+                                s.getParameters(),
+                                s.isEnabled()
+                        ))
+                        .toList() : null,
+                null
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public List<ValidationStepDto> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<ValidationStepDto> steps) {
+        this.steps = steps;
+    }
+
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
@@ -1,0 +1,43 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ValidationStepDto {
+    private String stepType;
+    private String fieldName;
+    private Map<String, Object> parameters;
+    private boolean isEnabled;
+
+    public String getStepType() {
+        return stepType;
+    }
+
+    public void setStepType(String stepType) {
+        this.stepType = stepType;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Object> parameters) {
+        this.parameters = parameters;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+}

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
@@ -6,17 +6,27 @@ import java.util.Map;
 import java.util.UUID;
 
 public class ValidationStepDto {
+    private UUID id;
     private ValidationStepType stepType;
     private String fieldName;
     private Map<String, String> parameters;
     private boolean isEnabled;
 
-    public ValidationStepDto(ValidationStepType stepType, String fieldName, Map<String, String> parameters,
+    public ValidationStepDto(UUID id, ValidationStepType stepType, String fieldName, Map<String, String> parameters,
                              boolean isEnabled) {
+        this.id = id;
         this.stepType = stepType;
         this.fieldName = fieldName;
         this.parameters = parameters;
         this.isEnabled = isEnabled;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public ValidationStepType getStepType() {

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationStepDto.java
@@ -1,19 +1,29 @@
 package com.dehold.contentmanager.validation.web.dto;
 
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+
 import java.util.Map;
 import java.util.UUID;
 
 public class ValidationStepDto {
-    private String stepType;
+    private ValidationStepType stepType;
     private String fieldName;
-    private Map<String, Object> parameters;
+    private Map<String, String> parameters;
     private boolean isEnabled;
 
-    public String getStepType() {
+    public ValidationStepDto(ValidationStepType stepType, String fieldName, Map<String, String> parameters,
+                             boolean isEnabled) {
+        this.stepType = stepType;
+        this.fieldName = fieldName;
+        this.parameters = parameters;
+        this.isEnabled = isEnabled;
+    }
+
+    public ValidationStepType getStepType() {
         return stepType;
     }
 
-    public void setStepType(String stepType) {
+    public void setStepType(ValidationStepType stepType) {
         this.stepType = stepType;
     }
 
@@ -25,11 +35,11 @@ public class ValidationStepDto {
         this.fieldName = fieldName;
     }
 
-    public Map<String, Object> getParameters() {
+    public Map<String, String> getParameters() {
         return parameters;
     }
 
-    public void setParameters(Map<String, Object> parameters) {
+    public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;
     }
 

--- a/src/main/resources/content-manager-requests/validation-pipelines/folder.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: validation-pipelines
+  seq: 6
+}
+
+auth {
+  mode: inherit
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - delete.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - delete.bru
@@ -1,0 +1,20 @@
+meta {
+  name: validation-pipelines - delete
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/api/validation-pipelines/:id
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: cfe786d4-1303-4cae-978f-df93b4b84a6b
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - get.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - get.bru
@@ -1,0 +1,20 @@
+meta {
+  name: validation-pipelines - get
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/validation-pipelines/:id
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: 70dd5102-bed0-4e57-8571-66d99d7ea851
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - getByIdAndContentType.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - getByIdAndContentType.bru
@@ -1,0 +1,21 @@
+meta {
+  name: validation-pipelines - getByIdAndContentType
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/validation-pipelines?userId=123e4567-e89b-12d3-a456-426614174000&contentType='blogpost'
+  body: none
+  auth: inherit
+}
+
+params:query {
+  userId: 123e4567-e89b-12d3-a456-426614174000
+  contentType: 'blogpost'
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - update.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines - update.bru
@@ -1,0 +1,43 @@
+meta {
+  name: validation-pipelines - update
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/validation-pipelines/:id
+  body: json
+  auth: inherit
+}
+
+params:path {
+  id: cfe786d4-1303-4cae-978f-df93b4b84a6b
+}
+
+body:json {
+  {
+    "id": "cfe786d4-1303-4cae-978f-df93b4b84a6b",
+    "userId": "123e4567-e89b-12d3-a456-426614174000",
+    "description": "THIS WAS UPDATED",
+    "contentType": "blogpost",
+    "steps": [
+      {
+        "id": "b348213f-a939-4f04-b1a7-9d01a952879f",
+        "pipelineId": "cfe786d4-1303-4cae-978f-df93b4b84a6b",
+        "stepType": "LENGTH_VALIDATION",
+        "fieldName": "title",
+        "parameters": {
+          "minLength": "10",
+          "maxLength": "50"
+        },
+        "enabled": true
+      }
+    ],
+    "createdAt": "2025-11-05T13:55:25.228943Z"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines-create.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines-create.bru
@@ -1,0 +1,36 @@
+meta {
+  name: validation-pipelines-create
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/validation-pipelines
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "userId": "123e4567-e89b-12d3-a456-426614174000",
+    "description": "Sample validation pipeline",
+    "contentType": "blogpost",
+    "steps": [
+      {
+        "stepType": "LENGTH_VALIDATION",
+        "fieldName": "title",
+        "parameters": {
+          "minLength": "5",
+          "maxLength": "50"
+        },
+        "enabled": true
+      }
+    ]
+  }
+  
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -123,4 +123,51 @@ class ValidationPipelineControllerTest {
         assertEquals(404, getResponse.getStatusCode().value());
     }
 
+    @Test
+    void givenPipelineExists_whenGetByUserIdAndContentType_thenReturnsPipeline() {
+        var userId = UUID.randomUUID();
+        var contentType = "BlogPost";
+
+        var createRequestDto = new ValidationPipelineCreateDto();
+        createRequestDto.setUserId(userId);
+        createRequestDto.setContentType(contentType);
+        createRequestDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+
+        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createRequestDto, ValidationPipelineModel.class);
+        var createdPipeline = createResponse.getBody();
+        assertEquals(201, createResponse.getStatusCode().value());
+        assertNotNull(createdPipeline);
+
+        String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
+                port, userId, contentType);
+        ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
+                url,
+                ValidationPipelineModel.class);
+
+        assertEquals(200, getResponse.getStatusCode().value());
+        var fetchedPipeline = getResponse.getBody();
+        assertNotNull(fetchedPipeline);
+        assertEquals(createdPipeline.getId(), fetchedPipeline.getId());
+    }
+
+    @Test
+    void givenPipelineDoesNotExist_whenGetByUserIdAndContentType_thenReturnsEmptyResult() {
+        var userId = UUID.randomUUID();
+        var contentType = "NonExistentContentType";
+
+        String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
+                port, userId, contentType);
+        ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
+                url,
+                ValidationPipelineModel.class);
+
+        assertEquals(200, getResponse.getStatusCode().value());
+        var fetchedPipeline = getResponse.getBody();
+        assertNull(fetchedPipeline);
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -41,7 +41,7 @@ class ValidationPipelineControllerTest {
                         "maxLength", "500"), true)
         ));
 
-        var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+        var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 requestDto, ValidationPipelineModel.class);
 
         assertEquals(201, response.getStatusCode().value());
@@ -63,7 +63,7 @@ class ValidationPipelineControllerTest {
                         "maxLength", "500"), true)
         ));
 
-        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createRequestDto, ValidationPipelineModel.class);
         var createdPipeline = createResponse.getBody();
         assertEquals(201, createResponse.getStatusCode().value());
@@ -81,7 +81,7 @@ class ValidationPipelineControllerTest {
 
         HttpEntity<ValidationPipelineUpdateDto> requestEntity = new HttpEntity<>(updateRequestDto);
         ResponseEntity<ValidationPipelineModel> response =
-                restTemplate.exchange("http://localhost:" + port + "/api/validation-pipeline/" +
+                restTemplate.exchange("http://localhost:" + port + "/api/validation-pipelines/" +
                         createdPipeline.getId(), HttpMethod.PUT,
                         requestEntity, ValidationPipelineModel.class);
 
@@ -104,20 +104,20 @@ class ValidationPipelineControllerTest {
                         "maxLength", "500"), true)
         ));
 
-        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createRequestDto, ValidationPipelineModel.class);
         var createdPipeline = createResponse.getBody();
         assertEquals(201, createResponse.getStatusCode().value());
         assertNotNull(createdPipeline);
 
         ResponseEntity<Void> deleteResponse = restTemplate.exchange(
-                "http://localhost:" + port + "/api/validation-pipeline/" + createdPipeline.getId(),
+                "http://localhost:" + port + "/api/validation-pipelines/" + createdPipeline.getId(),
                 HttpMethod.DELETE, null, Void.class);
 
         assertEquals(204, deleteResponse.getStatusCode().value());
 
         ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
-                "http://localhost:" + port + "/api/validation-pipeline/" + createdPipeline.getId(),
+                "http://localhost:" + port + "/api/validation-pipelines/" + createdPipeline.getId(),
                 ValidationPipelineModel.class);
 
         assertEquals(404, getResponse.getStatusCode().value());

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -1,5 +1,6 @@
 package com.dehold.contentmanager.validation.web;
 
+import com.dehold.contentmanager.exception.CustomErrorResponse;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
@@ -171,4 +172,19 @@ class ValidationPipelineControllerTest {
         assertNull(fetchedPipeline);
     }
 
+    @Test
+    void givenPipelineDoesNotExist_whenGetById_thenReturnsNotFound() {
+        var nonExistentId = UUID.randomUUID();
+
+        ResponseEntity<CustomErrorResponse> getResponse = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/validation-pipelines/" + nonExistentId,
+                CustomErrorResponse.class);
+
+        assertEquals(404, getResponse.getStatusCode().value());
+        assertNotNull(getResponse.getBody());
+        CustomErrorResponse errorResponse = getResponse.getBody();
+        assertTrue(errorResponse.getError().contains("The entity ValidationPipeline with id " + nonExistentId +
+                " does not exist"));
+        assertTrue(errorResponse.getPath().contains("/api/validation-pipelines/" + nonExistentId));
+    }
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -94,4 +94,33 @@ class ValidationPipelineControllerTest {
         assertEquals("content", updatedPipeline.getSteps().getFirst().getFieldName());
     }
 
+    @Test
+    void givenPipelineExists_whenDeletePipeline_thenPipelineIsDeleted() {
+        var createRequestDto = new ValidationPipelineCreateDto();
+        createRequestDto.setUserId(UUID.randomUUID());
+        createRequestDto.setContentType("BlogPost");
+        createRequestDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+
+        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+                createRequestDto, ValidationPipelineModel.class);
+        var createdPipeline = createResponse.getBody();
+        assertEquals(201, createResponse.getStatusCode().value());
+        assertNotNull(createdPipeline);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "http://localhost:" + port + "/api/validation-pipeline/" + createdPipeline.getId(),
+                HttpMethod.DELETE, null, Void.class);
+
+        assertEquals(204, deleteResponse.getStatusCode().value());
+
+        ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/validation-pipeline/" + createdPipeline.getId(),
+                ValidationPipelineModel.class);
+
+        assertEquals(404, getResponse.getStatusCode().value());
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -154,6 +154,10 @@ class ValidationPipelineControllerTest {
         var fetchedPipeline = getResponse.getBody();
         assertNotNull(fetchedPipeline);
         assertEquals(createdPipeline.getId(), fetchedPipeline.getId());
+        assertEquals(createdPipeline.getUserId(), fetchedPipeline.getUserId());
+        assertEquals(createdPipeline.getContentType(), fetchedPipeline.getContentType());
+        assertEquals(createdPipeline.getSteps().size(), fetchedPipeline.getSteps().size());
+        assertEquals(createdPipeline.getCreatedAt(), fetchedPipeline.getCreatedAt());
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -1,0 +1,51 @@
+package com.dehold.contentmanager.validation.web;
+
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
+import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ValidationPipelineControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void givenCreateValidationPipelineRequest_whenCreateValidationPipeline_thenReturnsCreatedPipeline() {
+        var requestDto = new ValidationPipelineCreateDto();
+        requestDto.setUserId(UUID.randomUUID());
+        requestDto.setContentType("BlogPost");
+        requestDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+
+        var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+                requestDto, ValidationPipelineModel.class);
+
+        assertEquals(201, response.getStatusCode().value());
+        var createdPipeline = response.getBody();
+        assertNotNull(createdPipeline);
+        assertEquals(requestDto.getUserId(), createdPipeline.getUserId());
+        assertEquals(requestDto.getContentType(), createdPipeline.getContentType());
+        assertEquals(1, createdPipeline.getSteps().size());
+        assertEquals(ValidationStepType.LENGTH_VALIDATION, createdPipeline.getSteps().getFirst().getStepType());
+    }
+
+}

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -3,12 +3,17 @@ package com.dehold.contentmanager.validation.web;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
+import com.dehold.contentmanager.validation.web.dto.ValidationPipelineUpdateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 import java.util.Map;
@@ -46,6 +51,47 @@ class ValidationPipelineControllerTest {
         assertEquals(requestDto.getContentType(), createdPipeline.getContentType());
         assertEquals(1, createdPipeline.getSteps().size());
         assertEquals(ValidationStepType.LENGTH_VALIDATION, createdPipeline.getSteps().getFirst().getStepType());
+    }
+
+    @Test
+    void givenUpdateRequest_whenValidationPipelineExists_thenUpdatesPipeline() {
+        var createRequestDto = new ValidationPipelineCreateDto();
+        createRequestDto.setUserId(UUID.randomUUID());
+        createRequestDto.setContentType("BlogPost");
+        createRequestDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+
+        var createResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipeline",
+                createRequestDto, ValidationPipelineModel.class);
+        var createdPipeline = createResponse.getBody();
+        assertEquals(201, createResponse.getStatusCode().value());
+        assertNotNull(createdPipeline);
+
+        var updateRequestDto = new ValidationPipelineUpdateDto();
+        updateRequestDto.setId(createdPipeline.getId());
+        updateRequestDto.setUserId(createdPipeline.getUserId());
+        updateRequestDto.setContentType(createdPipeline.getContentType());
+        UUID validationStepId = createdPipeline.getSteps().getFirst().getId();
+        updateRequestDto.setSteps(List.of(
+                new ValidationStepDto(validationStepId, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "50",
+                        "maxLength", "2000"), true)
+        ));
+
+        HttpEntity<ValidationPipelineUpdateDto> requestEntity = new HttpEntity<>(updateRequestDto);
+        ResponseEntity<ValidationPipelineModel> response =
+                restTemplate.exchange("http://localhost:" + port + "/api/validation-pipeline/" +
+                        createdPipeline.getId(), HttpMethod.PUT,
+                        requestEntity, ValidationPipelineModel.class);
+
+        assertEquals(200, response.getStatusCode().value());
+        var updatedPipeline = response.getBody();
+        assertNotNull(updatedPipeline);
+        assertEquals(updatedPipeline.getId(), createdPipeline.getId());
+        assertEquals(1, updatedPipeline.getSteps().size());
+        assertEquals(validationStepId, updatedPipeline.getSteps().getFirst().getId());
+        assertEquals("content", updatedPipeline.getSteps().getFirst().getFieldName());
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -47,10 +46,12 @@ class ValidationPipelineControllerTest {
         assertEquals(201, response.getStatusCode().value());
         var createdPipeline = response.getBody();
         assertNotNull(createdPipeline);
+        assertNotNull(createdPipeline.getId());
         assertEquals(requestDto.getUserId(), createdPipeline.getUserId());
         assertEquals(requestDto.getContentType(), createdPipeline.getContentType());
         assertEquals(1, createdPipeline.getSteps().size());
         assertEquals(ValidationStepType.LENGTH_VALIDATION, createdPipeline.getSteps().getFirst().getStepType());
+        assertEquals(createdPipeline.getId(), createdPipeline.getSteps().getFirst().getPipelineId());
     }
 
     @Test


### PR DESCRIPTION
Closes #42 

With this PR, there is a validation pipeline api introduced: `/api/validation-pipelines` for creating, updating, retrieving, and deleting `ValidationPipelines`.