### PR TITLE
Fix ValidationPipeline GET API

### DIFF
--- a/src/main/java/com/dehold/contentmanager/user/service/UserService.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface UserService {
@@ -17,5 +18,5 @@ public interface UserService {
 
     void deleteUser(UUID id);
 
-    ValidationPipelineModel getValidationPipelineByUserIdAndContentType(UUID userId, String contentType);
+    List<ValidationPipelineModel> getValidationPipelineByUserIdAndContentType(UUID userId, String contentType);
 }

--- a/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/user/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import com.dehold.contentmanager.validation.service.ValidationPipelineService;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -62,8 +63,8 @@ public class UserServiceImpl implements UserService {
         userRepository.deleteUser(id);
     }
 
-    public ValidationPipelineModel getValidationPipelineByUserIdAndContentType(UUID userId,
-                                                                                       String contentType) {
+    public List<ValidationPipelineModel> getValidationPipelineByUserIdAndContentType(UUID userId,
+                                                                                     String contentType) {
         getUser(userId); // Ensure user exists
         return validationPipelineService.findByUserIdAndContentType(userId, contentType);
     }

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -54,9 +54,6 @@ public class ValidationPipelineRepository {
                 pipeline.getCreatedAt()
         );
 
-        System.out.println("Inserted pipeline with ID: " + pipeline.getId() + ", Rows affected: " + rowsAffected);
-
-
         if (pipeline.getSteps() != null) {
             for (ValidationStepModel step : pipeline.getSteps()) {
                 step.setId(UUID.randomUUID());

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -111,7 +111,7 @@ public class ValidationPipelineRepository {
         return pipelines;
     }
 
-    public Optional<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {
+    public List<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {
         List<ValidationPipelineModel> pipelines = jdbcTemplate.query(
                 "SELECT * FROM validation_pipeline WHERE user_id = ? AND content_type = ?",
                 VALIDATION_PIPELINE_ROW_MAPPER,
@@ -120,14 +120,14 @@ public class ValidationPipelineRepository {
         );
 
         if (pipelines.isEmpty()) {
-            return Optional.empty();
+            return List.of();
         }
 
         ValidationPipelineModel pipeline = pipelines.getFirst();
         List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
         pipeline.setSteps(steps);
 
-        return Optional.of(pipeline);
+        return List.of(pipeline);
     }
 
     public void deleteById(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -123,11 +123,17 @@ public class ValidationPipelineRepository {
             return List.of();
         }
 
-        ValidationPipelineModel pipeline = pipelines.getFirst();
-        List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
-        pipeline.setSteps(steps);
+        pipelines = addValidationSteps(pipelines);
 
-        return List.of(pipeline);
+        return pipelines;
+    }
+
+    private List<ValidationPipelineModel> addValidationSteps(List<ValidationPipelineModel> pipelines) {
+        for(ValidationPipelineModel pipeline : pipelines) {
+            List<ValidationStepModel> steps = loadStepsForPipeline(pipeline.getId());
+            pipeline.setSteps(steps);
+        }
+        return pipelines;
     }
 
     public void deleteById(UUID id) {

--- a/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
+++ b/src/main/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepository.java
@@ -45,7 +45,7 @@ public class ValidationPipelineRepository {
             pipeline.setCreatedAt(Instant.now());
         }
 
-        jdbcTemplate.update(
+        int rowsAffected = jdbcTemplate.update(
                 "INSERT INTO validation_pipeline (id, user_id, description, content_type, created_at) VALUES (?, ?, ?, ?, ?)",
                 pipeline.getId(),
                 pipeline.getUserId(),
@@ -53,6 +53,9 @@ public class ValidationPipelineRepository {
                 pipeline.getContentType(),
                 pipeline.getCreatedAt()
         );
+
+        System.out.println("Inserted pipeline with ID: " + pipeline.getId() + ", Rows affected: " + rowsAffected);
+
 
         if (pipeline.getSteps() != null) {
             for (ValidationStepModel step : pipeline.getSteps()) {

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationPipelineService.java
@@ -25,8 +25,8 @@ public class ValidationPipelineService {
         return entity;
     }
 
-    public ValidationPipelineModel findByUserIdAndContentType(UUID userId, String contentType) {
-        return repository.findByUserIdAndContentType(userId, contentType).orElse(null);
+    public List<ValidationPipelineModel> findByUserIdAndContentType(UUID userId, String contentType) {
+        return repository.findByUserIdAndContentType(userId, contentType);
     }
 
 

--- a/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/ValidationPipelineController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -30,11 +31,12 @@ public class ValidationPipelineController {
     }
 
     @GetMapping
-    public ResponseEntity<ValidationPipelineModel> getValidationPipelineByUserIdAndContentType(
+    public ResponseEntity<List<ValidationPipelineModel>> getValidationPipelineByUserIdAndContentType(
             @RequestParam UUID userId,
             @RequestParam String contentType) {
-        ValidationPipelineModel model = validationPipelineService.findByUserIdAndContentType(userId, contentType);
-        return new ResponseEntity<>(model, HttpStatus.OK);
+        List<ValidationPipelineModel> response = validationPipelineService.findByUserIdAndContentType(userId,
+                contentType);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -61,8 +61,7 @@ CREATE TABLE validation_pipeline (
     user_id UUID NOT NULL,
     description VARCHAR(500),
     content_type VARCHAR(50) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(user_id, content_type)
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE validation_step (

--- a/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/repository/ValidationPipelineRepositoryTest.java
@@ -61,10 +61,11 @@ class ValidationPipelineRepositoryTest {
 
         cut.save(pipeline);
 
-        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
-        assertTrue(result.isPresent());
+        List<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
 
-        ValidationPipelineModel savedPipeline = result.get();
+        ValidationPipelineModel savedPipeline = result.getFirst();
         assertEquals(pipelineId, savedPipeline.getId());
         assertEquals(userId, savedPipeline.getUserId());
         assertEquals(description, savedPipeline.getDescription());
@@ -117,10 +118,11 @@ class ValidationPipelineRepositoryTest {
         );
         cut.save(updatedPipeline);
 
-        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
-        assertTrue(result.isPresent());
+        List<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
 
-        ValidationPipelineModel savedPipeline = result.get();
+        ValidationPipelineModel savedPipeline = result.getFirst();
         assertEquals(pipelineId, savedPipeline.getId());
         assertEquals("Updated description", savedPipeline.getDescription());
         assertEquals(1, savedPipeline.getSteps().size());
@@ -168,10 +170,11 @@ class ValidationPipelineRepositoryTest {
 
         cut.save(pipeline);
 
-        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, "blogpost");
-        assertTrue(result.isPresent());
+        List<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, "blogpost");
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
 
-        ValidationPipelineModel savedPipeline = result.get();
+        ValidationPipelineModel savedPipeline = result.getFirst();
         assertEquals(2, savedPipeline.getSteps().size());
 
         ValidationStepModel savedLengthStep = savedPipeline.getSteps().stream()
@@ -272,10 +275,11 @@ class ValidationPipelineRepositoryTest {
         );
         cut.save(pipeline);
 
-        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        List<ValidationPipelineModel> result = cut.findByUserIdAndContentType(userId, contentType);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
 
-        assertTrue(result.isPresent());
-        ValidationPipelineModel foundPipeline = result.get();
+        ValidationPipelineModel foundPipeline = result.getFirst();
         assertEquals("Test pipeline", foundPipeline.getDescription());
         assertEquals(2, foundPipeline.getSteps().size());
 
@@ -298,9 +302,9 @@ class ValidationPipelineRepositoryTest {
 
     @Test
     void givenPipelineDoesNotExist_whenFindByUserIdAndContentType_thenReturnsEmpty() {
-        Optional<ValidationPipelineModel> result = cut.findByUserIdAndContentType(UUID.randomUUID(), "nonexistent");
+        List<ValidationPipelineModel> result = cut.findByUserIdAndContentType(UUID.randomUUID(), "nonexistent");
 
-        assertFalse(result.isPresent());
+        assertTrue(result.isEmpty());
     }
 
     @Test
@@ -330,11 +334,11 @@ class ValidationPipelineRepositoryTest {
         );
         cut.save(pipeline);
 
-        assertTrue(cut.findByUserIdAndContentType(userId, "blogpost").isPresent());
+        assertEquals(1, cut.findByUserIdAndContentType(userId, "blogpost").size());
 
         cut.deleteById(pipelineId);
 
-        assertFalse(cut.findByUserIdAndContentType(userId, "blogpost").isPresent());
+        assertEquals(0, cut.findByUserIdAndContentType(userId, "blogpost").size());
 
         int stepCount = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM validation_step WHERE pipeline_id = ?",

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -3,7 +3,6 @@ package com.dehold.contentmanager.validation.web;
 import com.dehold.contentmanager.exception.CustomErrorResponse;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
-import com.dehold.contentmanager.validation.repository.ValidationPipelineRepository;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineUpdateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
@@ -31,9 +30,6 @@ class ValidationPipelineControllerTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
-
-    @Autowired
-    private ValidationPipelineRepository repository;
 
     @Test
     void givenCreateValidationPipelineRequest_whenCreateValidationPipeline_thenReturnsCreatedPipeline() {
@@ -191,8 +187,6 @@ class ValidationPipelineControllerTest {
         ));
         restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createRequestDto2, ValidationPipelineModel.class);
-
-        List<ValidationPipelineModel> allPipelines = repository.findAll();
 
         String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
                 port, userId, contentType);

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -169,6 +169,7 @@ class ValidationPipelineControllerTest {
         var createRequestDto1 = new ValidationPipelineCreateDto();
         createRequestDto1.setUserId(userId);
         createRequestDto1.setContentType(contentType);
+        createRequestDto1.setDescription("First Pipeline");
         createRequestDto1.setSteps(List.of(
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
                         "maxLength", "500"), true)
@@ -179,6 +180,7 @@ class ValidationPipelineControllerTest {
         var createRequestDto2 = new ValidationPipelineCreateDto();
         createRequestDto2.setUserId(userId);
         createRequestDto2.setContentType(contentType);
+        createRequestDto2.setDescription("Second Pipeline");
         createRequestDto2.setSteps(List.of(
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10",
                         "maxLength", "500"), true)

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -201,6 +201,23 @@ class ValidationPipelineControllerTest {
     }
 
     @Test
+    void givenNoPipelineSatisfiesSearchCriteria_whenGetByUserIdAndContentType_thenReturnsEmptyList() {
+        var userId = UUID.randomUUID();
+        var contentType = "Article";
+
+        String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
+                port, userId, contentType);
+        ResponseEntity<ValidationPipelineModel[]> getResponse = restTemplate.getForEntity(
+                url,
+                ValidationPipelineModel[].class);
+
+        assertEquals(200, getResponse.getStatusCode().value());
+        assertNotNull(getResponse.getBody());
+        var fetchedPipelines = getResponse.getBody();
+        assertEquals(0, fetchedPipelines.length);
+    }
+
+    @Test
     void givenPipelineDoesNotExist_whenGetByUserIdAndContentType_thenReturnsEmptyResult() {
         var userId = UUID.randomUUID();
         var contentType = "NonExistentContentType";

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -162,6 +162,43 @@ class ValidationPipelineControllerTest {
     }
 
     @Test
+    void givenMultiplePipelinesExist_whenGetByUserIdAndContentType_thenReturnsAllPipelines() {
+        var userId = UUID.randomUUID();
+        var contentType = "BlogPost";
+
+        var createRequestDto1 = new ValidationPipelineCreateDto();
+        createRequestDto1.setUserId(userId);
+        createRequestDto1.setContentType(contentType);
+        createRequestDto1.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createRequestDto1, ValidationPipelineModel.class);
+
+        var createRequestDto2 = new ValidationPipelineCreateDto();
+        createRequestDto2.setUserId(userId);
+        createRequestDto2.setContentType(contentType);
+        createRequestDto2.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10",
+                        "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createRequestDto2, ValidationPipelineModel.class);
+
+        String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
+                port, userId, contentType);
+        ResponseEntity<ValidationPipelineModel[]> getResponse = restTemplate.getForEntity(
+                url,
+                ValidationPipelineModel[].class);
+
+        assertEquals(200, getResponse.getStatusCode().value());
+        var response = getResponse.getBody();
+        assertNotNull(response);
+        assertEquals(2, response.length);
+    }
+
+    @Test
     void givenPipelineDoesNotExist_whenGetByUserIdAndContentType_thenReturnsEmptyResult() {
         var userId = UUID.randomUUID();
         var contentType = "NonExistentContentType";

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -3,6 +3,7 @@ package com.dehold.contentmanager.validation.web;
 import com.dehold.contentmanager.exception.CustomErrorResponse;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
+import com.dehold.contentmanager.validation.repository.ValidationPipelineRepository;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineUpdateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
@@ -30,6 +31,9 @@ class ValidationPipelineControllerTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ValidationPipelineRepository repository;
 
     @Test
     void givenCreateValidationPipelineRequest_whenCreateValidationPipeline_thenReturnsCreatedPipeline() {
@@ -187,6 +191,8 @@ class ValidationPipelineControllerTest {
         ));
         restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createRequestDto2, ValidationPipelineModel.class);
+
+        List<ValidationPipelineModel> allPipelines = repository.findAll();
 
         String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
                 port, userId, contentType);

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -167,13 +167,14 @@ class ValidationPipelineControllerTest {
 
         String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
                 port, userId, contentType);
-        ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
+        ResponseEntity<ValidationPipelineModel[]> getResponse = restTemplate.getForEntity(
                 url,
-                ValidationPipelineModel.class);
+                ValidationPipelineModel[].class);
 
         assertEquals(200, getResponse.getStatusCode().value());
-        var fetchedPipeline = getResponse.getBody();
-        assertNull(fetchedPipeline);
+        assertNotNull(getResponse.getBody());
+        var fetchedPipelines = getResponse.getBody();
+        assertEquals(0, fetchedPipelines.length);
     }
 
     @Test

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationPipelineControllerTest.java
@@ -146,13 +146,14 @@ class ValidationPipelineControllerTest {
 
         String url = String.format("http://localhost:%d/api/validation-pipelines?userId=%s&contentType=%s",
                 port, userId, contentType);
-        ResponseEntity<ValidationPipelineModel> getResponse = restTemplate.getForEntity(
+        ResponseEntity<ValidationPipelineModel[]> getResponse = restTemplate.getForEntity(
                 url,
-                ValidationPipelineModel.class);
+                ValidationPipelineModel[].class);
 
         assertEquals(200, getResponse.getStatusCode().value());
-        var fetchedPipeline = getResponse.getBody();
-        assertNotNull(fetchedPipeline);
+        var response = getResponse.getBody();
+        assertNotNull(response);
+        ValidationPipelineModel fetchedPipeline = getResponse.getBody()[0];
         assertEquals(createdPipeline.getId(), fetchedPipeline.getId());
         assertEquals(createdPipeline.getUserId(), fetchedPipeline.getUserId());
         assertEquals(createdPipeline.getContentType(), fetchedPipeline.getContentType());


### PR DESCRIPTION
Fixes #44 

Now the endpoint `/api/validation-pipelines?userId=&contentType=` returns a list of objects instead of only one object:

```json
[
  {
    "id": "6d07dee1-7c7b-407e-9a41-c37833b8f9e3",
    "userId": "123e4567-e89b-12d3-a456-426614174000",
    "description": "Sample validation pipeline",
    "contentType": "blogpost",
    "steps": [
      {
        "id": "9ad90c08-2ff1-40de-b14d-38bef15347f2",
        "pipelineId": "6d07dee1-7c7b-407e-9a41-c37833b8f9e3",
        "stepType": "LENGTH_VALIDATION",
        "fieldName": "title",
        "parameters": {
          "minLength": "5",
          "maxLength": "50"
        },
        "enabled": true
      }
    ],
    "createdAt": "2025-11-05T16:55:18.209600Z"
  }
]

```