### PR TITLE
Users Endpoint to Run Validations Per User

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ By checking the `web` and `service` layers, you can get a good idea of the detai
 | PUT | `/api/users/{id}` | Update existing user |
 | DELETE | `/api/users/{id}` | Delete user |
 | GET | `/api/users/{id}/blogposts` | Retrieve blog posts owned by a specific user |
+| POST | `/api/users/{id}/validate-blogposts` | Run validations for all blog posts owned by the user and persist results |
 
 **User Model:**
 ```json

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ A Spring Boot service that helps create, manage, validate and moderate content. 
 
 Please update for each new feature:
 
-| date | contributor email | feature or bug? |feature summary | feature description |
-|------|-------------------|-----------------|----------------|---------------------|
-
+| date (YY-MM-DD) | contributor email | feature summary | feature description                                                                                                           | issue link |
+|-----------------|-------------------|------------|-------------------------------------------------------------------------------------------------------------------------------|------------|
+| 2025-11-12      |denis.h@turing.com | Add ednpoint to run validations against all blog posts | Endpoint `api/users/:id/validate-blogposts` that runs validations against all blog posts owned by the user and persists them. | [#52](https://github.com/Turing-dev-community/content-manager/issues/52)|
 
 ### Overview
 - **Content Management**: Create, read, update, and delete various content types

--- a/src/main/java/com/dehold/contentmanager/user/web/UserController.java
+++ b/src/main/java/com/dehold/contentmanager/user/web/UserController.java
@@ -92,4 +92,15 @@ public class UserController {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{id}/validate-blogposts")
+    public ResponseEntity<List<ValidationResponse>> validateBlogPostsForUser(@PathVariable UUID id) {
+        userService.getUser(id); // Check for the user to be existent
+        List<ValidationResult> results = validationService.runBlogPostValidation(id);
+        List<ValidationResponse> response = results.stream()
+                .map(ValidationResultDto::from)
+                .map(dto -> new ValidationResponse(BlogPost.class.getSimpleName(), dto))
+                .toList();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -77,12 +77,22 @@ public class ValidationServiceImpl implements ValidationService {
                 validationPipelineFactory.createValidationPipelineForUserAndContentType(userId,
                         "blogpost");
         List<ValidationResult> results = new LinkedList<>();
+        collectResults(blogPost, pipelines, results);
+        persistsResults(results);
+        return results;
+    }
+
+    private void collectResults(BlogPost blogPost, List<ValidationPipeline<BlogPost>> pipelines, List<ValidationResult> results) {
         for(ValidationPipeline<BlogPost> pipeline : pipelines) {
             ValidationResult result = pipeline.run(blogPost);
-            validationResultRepository.create(result);
             results.add(result);
         }
-        return results;
+    }
+
+    private void persistsResults(List<ValidationResult> results) {
+        for(ValidationResult result : results) {
+            this.createValidationResult(result);
+        }
     }
 
     private static ValidationStep<BlogPost> getBlogPostLengthValidator(BlogPostValidationRequest request, ValidationStepFactory factory) {

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -79,6 +79,7 @@ public class ValidationServiceImpl implements ValidationService {
         List<ValidationResult> results = new LinkedList<>();
         for(ValidationPipeline<BlogPost> pipeline : pipelines) {
             ValidationResult result = pipeline.run(blogPost);
+            validationResultRepository.create(result);
             results.add(result);
         }
         return results;

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -1,17 +1,13 @@
 package com.dehold.contentmanager.validation.service;
 
-import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.content.blogpost.service.BlogPostService;
-import com.dehold.contentmanager.validation.model.ContentTypeRegistry;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipeline;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipelineBuilder;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipelineFactory;
-import com.dehold.contentmanager.validation.pipeline.ValidationPipelineImpl;
 import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
-import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.step.ValidationStep;
 import com.dehold.contentmanager.validation.step.ValidationStepFactory;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;

--- a/src/main/resources/content-manager-requests/users/users-validateBlogposts.bru
+++ b/src/main/resources/content-manager-requests/users/users-validateBlogposts.bru
@@ -1,0 +1,22 @@
+meta {
+  name: users-validateBlogposts
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/users/:id/validate-blogposts
+  body: json
+  auth: inherit
+}
+
+params:path {
+  id: 6a8acf9b-c16f-4e2d-9b2d-5f600d04a0b3
+}
+
+body:json {
+  {
+    "name": "Updated User Name",
+    "identifier": "updated-user-identifier"
+  }
+}

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -7,10 +7,15 @@ import com.dehold.contentmanager.user.model.User;
 import com.dehold.contentmanager.user.repository.UserRepository;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
+import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationResult;
+import com.dehold.contentmanager.validation.model.ValidationStepType;
+import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
+import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
+import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,10 +26,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
 import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -296,4 +298,175 @@ class UserControllerIntegrationTest {
         CustomErrorResponse errorResponse = response.getBody();
         assertEquals("The entity User with id " + nonExistentUserId + " does not exist", errorResponse.getError());
     }
+
+    @Test
+    void givenOneBlogPostAndPersistedValidationPipeline_validateBlogPostsForUser_shouldReturnValidationResult() {
+        User user = new User(UUID.randomUUID(), "Pipeline User", "pipelineuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Test Blog Post Title", "This is test content for the blog post", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Test pipeline for blog post validation");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title",
+                        Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content",
+                        Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+
+        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
+
+        var response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
+                null, ValidationResponse[].class);
+
+        assertEquals(200, response.getStatusCode().value());
+        var results = response.getBody();
+        assertNotNull(results);
+        assertEquals(1, results.length);
+
+        ValidationResponse validationResponse = results[0];
+        assertEquals("BlogPost", validationResponse.getContentType());
+        ValidationResultDto result = validationResponse.getValidationResult();
+        assertEquals("BlogPost", result.getContentType());
+        assertEquals(user.getId(), result.getUserId());
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void givenInvalidBlogPostAndPersistedValidationPipeline_validateBlogPostsForUser_shouldReturnValidationResultWithErrors() {
+        User user = new User(UUID.randomUUID(), "Pipeline User", "pipelineuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Shrt", "Too short", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Test pipeline for blog post validation");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title",
+                        Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content",
+                        Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+
+        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
+
+        var response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
+                null, ValidationResponse[].class);
+
+        assertEquals(200, response.getStatusCode().value());
+        var results = response.getBody();
+        assertNotNull(results);
+        assertEquals(1, results.length);
+
+        ValidationResponse validationResponse = results[0];
+        assertEquals("BlogPost", validationResponse.getContentType());
+        ValidationResultDto result = validationResponse.getValidationResult();
+        assertEquals("BlogPost", result.getContentType());
+        assertEquals(user.getId(), result.getUserId());
+        assertFalse(result.isValid());
+        assertEquals(2, result.getErrors().size());
+        assertTrue(result.getErrors().stream().anyMatch(
+                e -> e.code().equals(LengthValidator.ERROR_CODE) &&
+                        e.message().equals(LengthValidator.errorMessageTooShort("title"))
+        ));
+        assertTrue(result.getErrors().stream().anyMatch(
+                e -> e.code().equals(LengthValidator.ERROR_CODE) &&
+                        e.message().equals(LengthValidator.errorMessageTooShort("content"))
+        ));
+    }
+
+    @Test
+    void givenMultipleBlogPostsWithViolationsAndPersistedValidationPipeline_validateBlogPostsForUser_shouldReturnAllValidationResults() {
+        User user = new User(UUID.randomUUID(), "Pipeline User", "pipelineuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        BlogPost blogPost1 = new BlogPost(UUID.randomUUID(), "Hi", "This is valid content for the first blog post", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost1);
+
+        BlogPost blogPost2 = new BlogPost(UUID.randomUUID(), "Valid Title Here", "Short", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost2);
+
+        BlogPost blogPost3 = new BlogPost(UUID.randomUUID(), "Bad", "Bad", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost3);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Test pipeline for multiple blog post validation");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title",
+                        Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content",
+                        Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+
+        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
+
+        var response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
+                null, ValidationResponse[].class);
+
+        assertEquals(200, response.getStatusCode().value());
+        var results = response.getBody();
+        assertNotNull(results);
+        assertEquals(3, results.length);
+
+        for (ValidationResponse validationResponse : results) {
+            assertEquals("BlogPost", validationResponse.getContentType());
+            ValidationResultDto result = validationResponse.getValidationResult();
+            assertEquals("BlogPost", result.getContentType());
+            assertEquals(user.getId(), result.getUserId());
+            assertFalse(result.isValid());
+        }
+
+        int titleErrors = 0;
+        int contentErrors = 0;
+        int bothErrors = 0;
+
+        for (ValidationResponse validationResponse : results) {
+            ValidationResultDto result = validationResponse.getValidationResult();
+            boolean hasTitleError = result.getErrors().stream().anyMatch(
+                    e -> e.code().equals(LengthValidator.ERROR_CODE) &&
+                            e.message().equals(LengthValidator.errorMessageTooShort("title"))
+            );
+            boolean hasContentError = result.getErrors().stream().anyMatch(
+                    e -> e.code().equals(LengthValidator.ERROR_CODE) &&
+                            e.message().equals(LengthValidator.errorMessageTooShort("content"))
+            );
+
+            if (hasTitleError && hasContentError) {
+                bothErrors++;
+                assertEquals(2, result.getErrors().size());
+            } else if (hasTitleError) {
+                titleErrors++;
+                assertEquals(1, result.getErrors().size());
+            } else if (hasContentError) {
+                contentErrors++;
+                assertEquals(1, result.getErrors().size());
+            }
+        }
+
+        assertEquals(1, titleErrors);
+        assertEquals(1, contentErrors);
+        assertEquals(1, bothErrors);
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
+import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,6 +45,9 @@ class UserControllerIntegrationTest {
 
     @Autowired
     private BlogPostRepository blogPostRepository;
+
+    @Autowired
+    private ValidationResultRepository validationResultRepository;
 
     @Test
     void createUser_shouldReturnCreatedUser() {
@@ -467,6 +471,94 @@ class UserControllerIntegrationTest {
         assertEquals(1, titleErrors);
         assertEquals(1, contentErrors);
         assertEquals(1, bothErrors);
+    }
+
+    @Test
+    void givenOneBlogPostAndPipeline_whenValidateBlogPostsForUser_thenResultPersistedInDatabase() {
+        User user = new User(UUID.randomUUID(), "Persist User", "persistuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        BlogPost blogPost = new BlogPost(UUID.randomUUID(), "Valid Title", "This is sufficiently long content", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(blogPost);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Persistence test pipeline");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+        var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, pipelineCreateResponse.getStatusCode().value());
+
+        var validateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts", null, ValidationResponse[].class);
+        assertEquals(200, validateResponse.getStatusCode().value());
+        assertNotNull(validateResponse.getBody());
+        assertEquals(1, validateResponse.getBody().length);
+
+        List<ValidationResult> persisted = validationResultRepository.findByUserId(user.getId());
+        assertEquals(1, persisted.size());
+        ValidationResult result = persisted.getFirst();
+        assertEquals(user.getId(), result.getUserId());
+        assertEquals(blogPost.getId(), result.getContentId());
+        assertTrue(result.isValid());
+        assertEquals(0, result.getErrors().size());
+    }
+
+    @Test
+    void givenMultipleBlogPostsAndPipeline_whenValidateBlogPostsForUser_thenAllResultsPersistedInDatabase() {
+        User user = new User(UUID.randomUUID(), "Persist Multi User", "persistmulti-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        BlogPost validPost = new BlogPost(UUID.randomUUID(), "Valid Title", "This content is definitely long enough", Instant.now(), Instant.now(), user.getId());
+        BlogPost shortTitlePost = new BlogPost(UUID.randomUUID(), "Bad", "Content that is long enough for validation", Instant.now(), Instant.now(), user.getId());
+        BlogPost shortContentPost = new BlogPost(UUID.randomUUID(), "Another Valid Title", "Short", Instant.now(), Instant.now(), user.getId());
+        BlogPost bothShortPost = new BlogPost(UUID.randomUUID(), "No", "Bad", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(validPost);
+        blogPostRepository.createBlogPost(shortTitlePost);
+        blogPostRepository.createBlogPost(shortContentPost);
+        blogPostRepository.createBlogPost(bothShortPost);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Persistence multi pipeline");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+        var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, pipelineCreateResponse.getStatusCode().value());
+
+        var validateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts", null, ValidationResponse[].class);
+        assertEquals(200, validateResponse.getStatusCode().value());
+        assertNotNull(validateResponse.getBody());
+        assertEquals(4, validateResponse.getBody().length);
+
+        List<ValidationResult> persisted = validationResultRepository.findByUserId(user.getId());
+        assertEquals(4, persisted.size());
+
+        Map<UUID, ValidationResult> byContentId = new HashMap<>();
+        for(ValidationResult r : persisted) {
+            byContentId.put(r.getContentId(), r);
+        }
+        assertTrue(byContentId.get(validPost.getId()).isValid());
+        assertTrue(byContentId.get(validPost.getId()).getErrors().isEmpty());
+
+        ValidationResult titleResult = byContentId.get(shortTitlePost.getId());
+        assertFalse(titleResult.isValid());
+        assertTrue(titleResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("title"))));
+
+        ValidationResult contentResult = byContentId.get(shortContentPost.getId());
+        assertFalse(contentResult.isValid());
+        assertTrue(contentResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("content"))));
+
+        ValidationResult bothResult = byContentId.get(bothShortPost.getId());
+        assertFalse(bothResult.isValid());
+        assertEquals(2, bothResult.getErrors().size());
+        assertTrue(bothResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("title"))));
+        assertTrue(bothResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("content"))));
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -324,8 +324,6 @@ class UserControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
@@ -365,8 +363,6 @@ class UserControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
@@ -421,8 +417,6 @@ class UserControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
@@ -489,8 +483,7 @@ class UserControllerIntegrationTest {
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
-        var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, pipelineCreateResponse.getStatusCode().value());
+        var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);;
 
         var validateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts", null, ValidationResponse[].class);
         assertEquals(200, validateResponse.getStatusCode().value());
@@ -529,7 +522,6 @@ class UserControllerIntegrationTest {
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
         var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, pipelineCreateResponse.getStatusCode().value());
 
         var validateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts", null, ValidationResponse[].class);
         assertEquals(200, validateResponse.getStatusCode().value());

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -178,6 +178,8 @@ class ValidationControllerIntegrationTest {
         var createBlogPostResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost,
                 BlogPost.class);
+        assertEquals(201, createBlogPostResponse.getStatusCode().value());
+        assertNotNull(createBlogPostResponse.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -192,6 +194,8 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);
@@ -220,6 +224,8 @@ class ValidationControllerIntegrationTest {
         var createBlogPostResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost,
                 BlogPost.class);
+        assertEquals(201, createBlogPostResponse.getStatusCode().value());
+        assertNotNull(createBlogPostResponse.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -234,6 +240,8 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);
@@ -271,16 +279,22 @@ class ValidationControllerIntegrationTest {
         BlogPost blogPost1 = new BlogPost(UUID.randomUUID(), "Hi", "This is valid content for the first blog post", Instant.now(), Instant.now(), userId);
         var createBlogPost1Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost1, BlogPost.class);
+        assertEquals(201, createBlogPost1Response.getStatusCode().value());
+        assertNotNull(createBlogPost1Response.getBody());
 
         //Violation in title
         BlogPost blogPost2 = new BlogPost(UUID.randomUUID(), "Valid Title Here", "Short", Instant.now(), Instant.now(), userId);
         var createBlogPost2Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost2, BlogPost.class);
+        assertEquals(201, createBlogPost2Response.getStatusCode().value());
+        assertNotNull(createBlogPost2Response.getBody());
 
         //Vioalation in both content and title
         BlogPost blogPost3 = new BlogPost(UUID.randomUUID(), "Bad", "Bad", Instant.now(), Instant.now(), userId);
         var createBlogPost3Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost3, BlogPost.class);
+        assertEquals(201, createBlogPost3Response.getStatusCode().value());
+        assertNotNull(createBlogPost3Response.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -295,6 +309,8 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, createPipelineResponse.getStatusCode().value());
+        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);

--- a/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/web/ValidationControllerIntegrationTest.java
@@ -178,8 +178,6 @@ class ValidationControllerIntegrationTest {
         var createBlogPostResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost,
                 BlogPost.class);
-        assertEquals(201, createBlogPostResponse.getStatusCode().value());
-        assertNotNull(createBlogPostResponse.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -194,8 +192,6 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);
@@ -224,8 +220,6 @@ class ValidationControllerIntegrationTest {
         var createBlogPostResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost,
                 BlogPost.class);
-        assertEquals(201, createBlogPostResponse.getStatusCode().value());
-        assertNotNull(createBlogPostResponse.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -240,8 +234,6 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);
@@ -279,22 +271,16 @@ class ValidationControllerIntegrationTest {
         BlogPost blogPost1 = new BlogPost(UUID.randomUUID(), "Hi", "This is valid content for the first blog post", Instant.now(), Instant.now(), userId);
         var createBlogPost1Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost1, BlogPost.class);
-        assertEquals(201, createBlogPost1Response.getStatusCode().value());
-        assertNotNull(createBlogPost1Response.getBody());
 
         //Violation in title
         BlogPost blogPost2 = new BlogPost(UUID.randomUUID(), "Valid Title Here", "Short", Instant.now(), Instant.now(), userId);
         var createBlogPost2Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost2, BlogPost.class);
-        assertEquals(201, createBlogPost2Response.getStatusCode().value());
-        assertNotNull(createBlogPost2Response.getBody());
 
         //Vioalation in both content and title
         BlogPost blogPost3 = new BlogPost(UUID.randomUUID(), "Bad", "Bad", Instant.now(), Instant.now(), userId);
         var createBlogPost3Response = restTemplate.postForEntity("http://localhost:" + port + "/api/blogposts",
                 blogPost3, BlogPost.class);
-        assertEquals(201, createBlogPost3Response.getStatusCode().value());
-        assertNotNull(createBlogPost3Response.getBody());
 
         var createPipelineDto = new ValidationPipelineCreateDto();
         createPipelineDto.setUserId(userId);
@@ -309,8 +295,6 @@ class ValidationControllerIntegrationTest {
 
         var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
-        assertEquals(201, createPipelineResponse.getStatusCode().value());
-        assertNotNull(createPipelineResponse.getBody());
 
         var response = restTemplate.postForEntity("http://localhost:" + port + "/api/validate/validate-blogposts?userId=" + userId,
                 null, ValidationResponse[].class);


### PR DESCRIPTION
Closes #52 

This PR adds an API endpoint that allows users to validate all blog posts they own against all validation pipelines they own.