### PR TITLE
Introduce Validation Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please update for each new feature:
 | date (YY-MM-DD) | contributor email | feature summary | feature description                                                                                                           | issue link |
 |-----------------|-------------------|------------|-------------------------------------------------------------------------------------------------------------------------------|------------|
 | 2025-11-12      |denis.h@turing.com | Add ednpoint to run validations against all blog posts | Endpoint `api/users/:id/validate-blogposts` that runs validations against all blog posts owned by the user and persists them. | [#52](https://github.com/Turing-dev-community/content-manager/issues/52)|
+| 2025-11-13      |denis.h@turing.com | Validation Reports | Added new endpoint `/api/users/:id/validation-report` that provides a summary report of validation results for all content owned by a user. | [#53](https://github.com/Turing-dev-community/content-manager/issues/57)|
 
 ### Overview
 - **Content Management**: Create, read, update, and delete various content types

--- a/src/main/java/com/dehold/contentmanager/user/web/UserController.java
+++ b/src/main/java/com/dehold/contentmanager/user/web/UserController.java
@@ -8,6 +8,7 @@ import com.dehold.contentmanager.user.web.dto.UserResponse;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.service.ValidationService;
+import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import org.springframework.http.HttpStatus;
@@ -72,6 +73,13 @@ public class UserController {
         List<ValidationResult> validationResults = validationService.findByUserId(id);
         List<ValidationResultDto> validationResultDtos = validationResults.stream().map(ValidationResultDto::from).toList();
         return ResponseEntity.ok(validationResultDtos);
+    }
+
+    @GetMapping("/{id}/validation-report")
+    public ResponseEntity<ValidationReportDto> getValidationReportByUserId(@PathVariable UUID id) {
+        userService.getUser(id); // Check for the user to be existent
+        ValidationReportDto report = validationService.generateValidationReport(id);
+        return ResponseEntity.ok(report);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
@@ -2,6 +2,7 @@ package com.dehold.contentmanager.validation.service;
 
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
+import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 
 import java.util.List;
@@ -16,4 +17,5 @@ public interface ValidationService {
 
     List<ValidationResult> runBlogPostValidation(UUID userId);
 
+    ValidationReportDto generateValidationReport(UUID userId);
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
@@ -14,5 +14,6 @@ public interface ValidationService {
 
     List<ValidationResult> findByUserId(UUID id);
 
-    public List<ValidationResult> runBlogPostValidation(UUID userId);
+    List<ValidationResult> runBlogPostValidation(UUID userId);
+
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -11,6 +11,7 @@ import com.dehold.contentmanager.validation.repository.ValidationResultRepositor
 import com.dehold.contentmanager.validation.step.ValidationStep;
 import com.dehold.contentmanager.validation.step.ValidationStepFactory;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
+import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.HashMap;
 
 @Service
 public class ValidationServiceImpl implements ValidationService {
@@ -66,6 +68,20 @@ public class ValidationServiceImpl implements ValidationService {
             allResults.addAll(results);
         }
         return allResults;
+    }
+
+    @Override
+    public ValidationReportDto generateValidationReport(UUID userId) {
+        List<ValidationResult> results = validationResultRepository.findByUserId(userId);
+        int totalErrorCount = 0;
+        Map<String, Integer> codeCounts = new HashMap<>();
+        for (ValidationResult result : results) {
+            totalErrorCount += result.getErrors().size();
+            result.getErrors().forEach(error -> codeCounts.merge(error.code(), 1, Integer::sum));
+        }
+        Map<String, String> errorCodeToErrorCount = new HashMap<>();
+        codeCounts.forEach((k, v) -> errorCodeToErrorCount.put(k, String.valueOf(v)));
+        return new ValidationReportDto(totalErrorCount, errorCodeToErrorCount);
     }
 
     private List<ValidationResult> runValidationPipelinesForBlogPost(UUID userId, BlogPost blogPost) {

--- a/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationReportDto.java
+++ b/src/main/java/com/dehold/contentmanager/validation/web/dto/ValidationReportDto.java
@@ -1,0 +1,31 @@
+package com.dehold.contentmanager.validation.web.dto;
+
+import java.util.Map;
+
+public class ValidationReportDto {
+    int totalErrorCount;
+    Map<String, String> errorCodeToErrorCount;
+
+    public ValidationReportDto(int totalErrorCount, Map<String, String> errorCodeToErrorCount) {
+        this.totalErrorCount = totalErrorCount;
+        this.errorCodeToErrorCount = errorCodeToErrorCount;
+    }
+
+    public int getTotalErrorCount() {
+        return totalErrorCount;
+    }
+
+    public void setTotalErrorCount(int totalErrorCount) {
+        this.totalErrorCount = totalErrorCount;
+    }
+
+    public Map<String, String> getErrorCodeToErrorCount() {
+        return errorCodeToErrorCount;
+    }
+
+    public void setErrorCodeToErrorCount(Map<String, String> errorCodeToErrorCount) {
+        this.errorCodeToErrorCount = errorCodeToErrorCount;
+    }
+
+
+}

--- a/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
+++ b/src/main/resources/content-manager-requests/blogposts/blogpost-create.bru
@@ -13,8 +13,8 @@ post {
 body:json {
   {
     "title": "This is a valid title: It's long enough",
-    "content": "This is a valid content: It's long enough.",
-    "userId": "428c9403-b848-4c86-a29f-c4bc17959ad7"
+    "content": "Short",
+    "userId": "cfae6bd8-0dd3-4d47-9ff1-da0d07b4d83f"
   }
 }
 

--- a/src/main/resources/content-manager-requests/users/users-validateBlogposts.bru
+++ b/src/main/resources/content-manager-requests/users/users-validateBlogposts.bru
@@ -11,7 +11,7 @@ post {
 }
 
 params:path {
-  id: 6a8acf9b-c16f-4e2d-9b2d-5f600d04a0b3
+  id: cfae6bd8-0dd3-4d47-9ff1-da0d07b4d83f
 }
 
 body:json {

--- a/src/main/resources/content-manager-requests/users/users-validation-report.bru
+++ b/src/main/resources/content-manager-requests/users/users-validation-report.bru
@@ -1,0 +1,20 @@
+meta {
+  name: users-validation-report
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/api/users/:id/validation-report
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: cfae6bd8-0dd3-4d47-9ff1-da0d07b4d83f
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines-create.bru
+++ b/src/main/resources/content-manager-requests/validation-pipelines/validation-pipelines-create.bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "userId": "428c9403-b848-4c86-a29f-c4bc17959ad7",
+    "userId": "cfae6bd8-0dd3-4d47-9ff1-da0d07b4d83f",
     "description": "Sample validation pipeline",
     "contentType": "blogpost",
     "steps": [

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -553,4 +553,6 @@ class UserControllerIntegrationTest {
         assertTrue(bothResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("content"))));
     }
 
+
+
 }

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -604,4 +604,53 @@ class UserControllerIntegrationTest {
         assertEquals(2, report.getErrorCodeToErrorCount().size());
     }
 
+    @Test
+    void givenValidationResultsForMultipleUsers_whenGetValidationReportForUser_thenReturnOnlyRequestedUsersCounts() {
+        User user1 = new User(UUID.randomUUID(), "Report User A", "reportA-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        User user2 = new User(UUID.randomUUID(), "Report User B", "reportB-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user1);
+        userRepository.createUser(user2);
+
+        BlogPost user1Valid = new BlogPost(UUID.randomUUID(), "Valid Title", "This content is sufficiently long", Instant.now(), Instant.now(), user1.getId());
+        BlogPost user1InvalidTitle = new BlogPost(UUID.randomUUID(), "Bad", "This content is sufficiently long", Instant.now(), Instant.now(), user1.getId());
+        BlogPost user2InvalidContent = new BlogPost(UUID.randomUUID(), "Another Valid Title", "Short", Instant.now(), Instant.now(), user2.getId());
+        blogPostRepository.createBlogPost(user1Valid);
+        blogPostRepository.createBlogPost(user1InvalidTitle);
+        blogPostRepository.createBlogPost(user2InvalidContent);
+
+        var pipelineDtoUser1 = new ValidationPipelineCreateDto();
+        pipelineDtoUser1.setUserId(user1.getId());
+        pipelineDtoUser1.setContentType("blogpost");
+        pipelineDtoUser1.setDescription("Report pipeline user1");
+        pipelineDtoUser1.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDtoUser1, ValidationPipelineModel.class);
+
+        var pipelineDtoUser2 = new ValidationPipelineCreateDto();
+        pipelineDtoUser2.setUserId(user2.getId());
+        pipelineDtoUser2.setContentType("blogpost");
+        pipelineDtoUser2.setDescription("Report pipeline user2");
+        pipelineDtoUser2.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDtoUser2, ValidationPipelineModel.class);
+
+        restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user1.getId() + "/validate-blogposts", null, ValidationResponse[].class);
+        restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user2.getId() + "/validate-blogposts", null, ValidationResponse[].class);
+
+        ResponseEntity<ValidationReportDto> reportResponse = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/users/" + user1.getId() + "/validation-report",
+                ValidationReportDto.class);
+        assertEquals(200, reportResponse.getStatusCode().value());
+        assertNotNull(reportResponse.getBody());
+        ValidationReportDto report = reportResponse.getBody();
+
+        assertEquals(1, report.getTotalErrorCount());
+        assertEquals("1", report.getErrorCodeToErrorCount().get(LengthValidator.ERROR_CODE));
+        assertEquals(1, report.getErrorCodeToErrorCount().size());
+    }
+
 }

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -11,8 +11,10 @@ import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.step.LengthValidator;
+import com.dehold.contentmanager.validation.step.PhoneNumberForbiddenValidator;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
 import com.dehold.contentmanager.validation.web.dto.ValidationPipelineCreateDto;
+import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
@@ -189,7 +191,6 @@ class UserControllerIntegrationTest {
         ValidationResponse validationResponse = restTemplate.postForEntity("http://localhost:" + port + "/api" +
                 "/validate/blogpost", request, ValidationResponse.class).getBody();
         assertNotNull(validationResponse);
-        ValidationResult validationResult = validationResponse.getValidationResult().toValidationResult();
 
         ResponseEntity<ValidationResultDto[]> response =
                 restTemplate.getForEntity("http://localhost:" + port + "/api/users/" +
@@ -322,7 +323,7 @@ class UserControllerIntegrationTest {
                         Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
 
-        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
 
         var response = restTemplate.postForEntity(
@@ -361,7 +362,7 @@ class UserControllerIntegrationTest {
                         Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
 
-        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
 
         var response = restTemplate.postForEntity(
@@ -415,7 +416,7 @@ class UserControllerIntegrationTest {
                         Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
 
-        var createPipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
                 createPipelineDto, ValidationPipelineModel.class);
 
         var response = restTemplate.postForEntity(
@@ -483,7 +484,7 @@ class UserControllerIntegrationTest {
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title", Map.of("minLength", "5", "maxLength", "100"), true),
                 new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content", Map.of("minLength", "10", "maxLength", "1000"), true)
         ));
-        var pipelineCreateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);;
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", createPipelineDto, ValidationPipelineModel.class);;
 
         var validateResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts", null, ValidationResponse[].class);
         assertEquals(200, validateResponse.getStatusCode().value());
@@ -553,6 +554,54 @@ class UserControllerIntegrationTest {
         assertTrue(bothResult.getErrors().stream().anyMatch(e -> e.code().equals(LengthValidator.ERROR_CODE) && e.message().equals(LengthValidator.errorMessageTooShort("content"))));
     }
 
+    @Test
+    void givenMultipleValidationResults_whenGetValidationReport_thenReturnCorrectReport() {
+        User user = new User(UUID.randomUUID(), "Report User", "reportuser-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
 
+        BlogPost phoneNumberIncludedInPost = new BlogPost(UUID.randomUUID(), "Valid Title", "This content is sufficiently long, call +1 234 567 8901", Instant.now(), Instant.now(), user.getId());
+        BlogPost shortTitlePost = new BlogPost(UUID.randomUUID(), "Bad", "This content is sufficiently long", Instant.now(), Instant.now(), user.getId());
+        BlogPost shortContentPost = new BlogPost(UUID.randomUUID(), "Another Valid Title", "Short", Instant.now(), Instant.now(), user.getId());
+        blogPostRepository.createBlogPost(phoneNumberIncludedInPost);
+        blogPostRepository.createBlogPost(shortTitlePost);
+        blogPostRepository.createBlogPost(shortContentPost);
+
+        var createPipelineDto = new ValidationPipelineCreateDto();
+        createPipelineDto.setUserId(user.getId());
+        createPipelineDto.setContentType("blogpost");
+        createPipelineDto.setDescription("Report pipeline");
+        createPipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "title",
+                        Map.of("minLength", "5", "maxLength", "100"), true),
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "content",
+                        Map.of("minLength", "10", "maxLength", "1000"), true),
+                new ValidationStepDto(null, ValidationStepType.PHONE_NUMBER_FORBIDDEN_VALIDATION, "content",
+                        Map.of(), true)
+        ));
+
+        var pipelineResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines",
+                createPipelineDto, ValidationPipelineModel.class);
+        assertEquals(201, pipelineResponse.getStatusCode().value());
+        assertNotNull(pipelineResponse.getBody());
+
+        var validateResponse = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-blogposts",
+                null, ValidationResponse[].class);
+        assertEquals(200, validateResponse.getStatusCode().value());
+        assertNotNull(validateResponse.getBody());
+        assertEquals(3, validateResponse.getBody().length);
+
+        ResponseEntity<ValidationReportDto> reportResponse = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validation-report",
+                ValidationReportDto.class);
+        assertEquals(200, reportResponse.getStatusCode().value());
+        assertNotNull(reportResponse.getBody());
+        ValidationReportDto report = reportResponse.getBody();
+
+        assertEquals(3, report.getTotalErrorCount());
+        assertEquals("2", report.getErrorCodeToErrorCount().get(LengthValidator.ERROR_CODE));
+        assertEquals("1", report.getErrorCodeToErrorCount().get(PhoneNumberForbiddenValidator.ERROR_CODE));
+        assertEquals(2, report.getErrorCodeToErrorCount().size());
+    }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -14,7 +14,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.Instant;
 import java.util.List;
@@ -151,7 +150,4 @@ class ValidationServiceTest {
         assertEquals("2", report.getErrorCodeToErrorCount().get(ForbiddenWordValidator.ERROR_CODE));
         assertEquals(2, report.getErrorCodeToErrorCount().size());
     }
-
-
-
 }

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -109,4 +109,19 @@ class ValidationServiceTest {
         assertEquals(2, report.getErrorCodeToErrorCount().size());
     }
 
+    @Test
+    void givenSeveralValidationResultsWithoutErrors_whenReport_thenShouldReturnZeroErrors() {
+        UUID userId = UUID.randomUUID();
+        ValidationResult result1 = ValidationResult.valid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId);
+        ValidationResult result2 = ValidationResult.valid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId);
+        ValidationResult result3 = ValidationResult.valid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId);
+        when(repository.findByUserId(userId)).thenReturn(List.of(result1, result2, result3));
+
+        ValidationReportDto report = validationService.generateValidationReport(userId);
+        assertNotNull(report);
+        assertEquals(0, report.getTotalErrorCount());
+        assertTrue(report.getErrorCodeToErrorCount().isEmpty());
+    }
+
 }
+

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -4,6 +4,7 @@ import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
+import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -13,12 +14,14 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ValidationServiceTest {
 
@@ -70,6 +73,18 @@ class ValidationServiceTest {
         assertEquals(BlogPost.class.getSimpleName(), captureResult.getContentType());
         assertEquals(blogPostValidationRequest.getBlogPost().getId(), captureResult.getContentId());
         assertTrue(captureResult.isValid());
+    }
+
+    @Test
+    void givenOneValidationResultWithoutErrors_whenReport_thenShouldReturnNoErrors() {
+        UUID userId = UUID.randomUUID();
+        ValidationResult result = ValidationResult.valid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId);
+        when(repository.findByUserId(userId)).thenReturn(List.of(result));
+
+        ValidationReportDto report = validationService.generateValidationReport(userId);
+        assertNotNull(report);
+        assertEquals(0, report.getTotalErrorCount());
+        assertTrue(report.getErrorCodeToErrorCount().isEmpty());
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -123,5 +123,35 @@ class ValidationServiceTest {
         assertTrue(report.getErrorCodeToErrorCount().isEmpty());
     }
 
-}
+    @Test
+    void givenSeveralValidationResultsWithErrors_whenReport_thenShouldReturnRightErrors() {
+        UUID userId = UUID.randomUUID();
+        List<ValidationError> errors1 = List.of(
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("title")),
+                new ValidationError(ForbiddenWordValidator.ERROR_CODE, "Forbidden word 'spam'")
+        );
+        List<ValidationError> errors2 = List.of(
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("content"))
+        );
+        List<ValidationError> errors3 = List.of(
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("title")),
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("content")),
+                new ValidationError(ForbiddenWordValidator.ERROR_CODE, "Forbidden word 'ads'")
+        );
+        ValidationResult result1 = ValidationResult.invalid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId,
+                errors1);
+        ValidationResult result2 = ValidationResult.invalid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId, errors2);
+        ValidationResult result3 = ValidationResult.invalid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId, errors3);
+        when(repository.findByUserId(userId)).thenReturn(List.of(result1, result2, result3));
 
+        ValidationReportDto report = validationService.generateValidationReport(userId);
+        assertNotNull(report);
+        assertEquals(6, report.getTotalErrorCount());
+        assertEquals("4", report.getErrorCodeToErrorCount().get(LengthValidator.ERROR_CODE));
+        assertEquals("2", report.getErrorCodeToErrorCount().get(ForbiddenWordValidator.ERROR_CODE));
+        assertEquals(2, report.getErrorCodeToErrorCount().size());
+    }
+
+
+
+}

--- a/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
+++ b/src/test/java/com/dehold/contentmanager/validation/service/ValidationServiceTest.java
@@ -1,8 +1,11 @@
 package com.dehold.contentmanager.validation.service;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
+import com.dehold.contentmanager.validation.step.ForbiddenWordValidator;
+import com.dehold.contentmanager.validation.step.LengthValidator;
 import com.dehold.contentmanager.validation.web.dto.BlogPostValidationRequest;
 import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,6 +88,25 @@ class ValidationServiceTest {
         assertNotNull(report);
         assertEquals(0, report.getTotalErrorCount());
         assertTrue(report.getErrorCodeToErrorCount().isEmpty());
+    }
+
+    @Test
+    void givenOneValidationResultWithSeveralErrors_whenReport_thenShouldReturnRightErrors() {
+        UUID userId = UUID.randomUUID();
+        List<ValidationError> errors = List.of(
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("title")),
+                new ValidationError(LengthValidator.ERROR_CODE, LengthValidator.errorMessageTooShort("content")),
+                new ValidationError(ForbiddenWordValidator.ERROR_CODE, "Forbidden word 'spam'")
+        );
+        ValidationResult result = ValidationResult.invalid(BlogPost.class.getSimpleName(), UUID.randomUUID(), userId, errors);
+        when(repository.findByUserId(userId)).thenReturn(List.of(result));
+
+        ValidationReportDto report = validationService.generateValidationReport(userId);
+        assertNotNull(report);
+        assertEquals(3, report.getTotalErrorCount());
+        assertEquals("2", report.getErrorCodeToErrorCount().get(LengthValidator.ERROR_CODE));
+        assertEquals("1", report.getErrorCodeToErrorCount().get(ForbiddenWordValidator.ERROR_CODE));
+        assertEquals(2, report.getErrorCodeToErrorCount().size());
     }
 
 }


### PR DESCRIPTION
Closes #57 

This PR introduces the endpoint `/api/users/:id/validation-report` that allows getting a summary of all error counts in this format:

```json
  {
    "totalErrorCount": 3,
    "errorCodeToErrorCount": {
        "FORBIDDEN_WORD_VALIDATION_FAILED": 1,
        "LENGTH_VALIDATION_FAILED": 2
    } 
  }
```