### PR TITLE
allow users to validate customer support responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please update for each new feature:
 | 2025-11-13      |denis.h@turing.com | Validation Reports | Added new endpoint `/api/users/:id/validation-report` that provides a summary report of validation results for all content owned by a user. | [#53](https://github.com/Turing-dev-community/content-manager/issues/57) |
 | 2025-11-14      |denis.h@turing.com | Introduce a Generic Content Model | More flexible content creation by providing a generic content model that allows custom content types and fields | [#61](https://github.com/Turing-dev-community/content-manager/issues/61) |
 | 2025-11-14      | riddhi.s@turing.com    | Add pagination to GET /api/blogposts               | Add `page` and `size` query params to blog post list endpoint. Return paginated response with metadata.                       | [#55](https://github.com/Turing-dev-community/content-manager/issues/55) |
+| 2025-11-15 | riddhi.s@turing.com | Allow users to validate customer support responses | Endpoint `/api/users/{id}/validate-supportresponses` that runs validations against all `SupportResponse` entries owned by the user and persists results. Fixes circular `NOT NULL` dependency in DB schema. | [#67](https://github.com/Turing-dev-community/content-manager/issues/67) |
 
 ### Overview
 - **Content Management**: Create, read, update, and delete various content types

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Please update for each new feature:
 | 2025-11-14      |denis.h@turing.com | Introduce a Generic Content Model | More flexible content creation by providing a generic content model that allows custom content types and fields | [#61](https://github.com/Turing-dev-community/content-manager/issues/61) |
 | 2025-11-14      | riddhi.s@turing.com    | Add pagination to GET /api/blogposts               | Add `page` and `size` query params to blog post list endpoint. Return paginated response with metadata.                       | [#55](https://github.com/Turing-dev-community/content-manager/issues/55) |
 | 2025-11-17 | riddhi.s@turing.com | Add ProductOffer content type | New marketplace-ready content type with pricing, stock, delivery fields. Model + repository + schema. No API yet. | [#74](https://github.com/Turing-dev-community/content-manager/issues/74) |
+| 2025-11-15 | riddhi.s@turing.com | Allow users to validate customer support responses | Endpoint `/api/users/{id}/validate-supportresponses` that runs validations against all `SupportResponse` entries owned by the user and persists results. Fixes circular `NOT NULL` dependency in DB schema. | [#67](https://github.com/Turing-dev-community/content-manager/issues/67) |
 
 ### Overview
 - **Content Management**: Create, read, update, and delete various content types

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/repository/SupportResponseRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -55,5 +56,12 @@ public class SupportResponseRepository {
         String sql = "DELETE FROM support_response WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    public List<SupportResponse> getSupportResponsesByUserId(UUID userId) {
+        String sql = "SELECT sr.* FROM support_response sr " +
+        "JOIN customer_request cr ON sr.support_request = cr.id " +
+        "WHERE cr.customer_id = ?";
+        return jdbcTemplate.query(sql, ROW_MAPPER, userId);
+        }
 }
 

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseService.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseService.java
@@ -1,7 +1,8 @@
 package com.dehold.contentmanager.content.customersupport.service;
 
 import com.dehold.contentmanager.content.customersupport.model.SupportResponse;
-import java.util.Optional;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface SupportResponseService {
@@ -9,5 +10,6 @@ public interface SupportResponseService {
     SupportResponse getSupportResponse(UUID id);
     void updateSupportResponse(SupportResponse response);
     void deleteSupportResponse(UUID id);
+    List<SupportResponse> getSupportResponsesByUserId(UUID userId);
 }
 

--- a/src/main/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/content/customersupport/service/SupportResponseServiceImpl.java
@@ -5,7 +5,7 @@ import com.dehold.contentmanager.content.customersupport.repository.SupportRespo
 import com.dehold.contentmanager.exception.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -35,5 +35,10 @@ public class SupportResponseServiceImpl implements SupportResponseService {
     @Override
     public void deleteSupportResponse(UUID id) {
         repository.delete(id);
+    }
+
+    @Override
+    public List<SupportResponse> getSupportResponsesByUserId(UUID userId) {
+        return repository.getSupportResponsesByUserId(userId);
     }
 }

--- a/src/main/java/com/dehold/contentmanager/user/web/UserController.java
+++ b/src/main/java/com/dehold/contentmanager/user/web/UserController.java
@@ -2,6 +2,7 @@ package com.dehold.contentmanager.user.web;
 
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.content.blogpost.service.BlogPostService;
+import com.dehold.contentmanager.content.customersupport.model.SupportResponse;
 import com.dehold.contentmanager.user.service.UserService;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UserResponse;
@@ -108,6 +109,17 @@ public class UserController {
         List<ValidationResponse> response = results.stream()
                 .map(ValidationResultDto::from)
                 .map(dto -> new ValidationResponse(BlogPost.class.getSimpleName(), dto))
+                .toList();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/{id}/validate-supportresponses")
+    public ResponseEntity<List<ValidationResponse>> validateSupportResponsesForUser(@PathVariable UUID id) {
+        userService.getUser(id); // Check for the user to be existent
+        List<ValidationResult> results = validationService.runSupportResponseValidation(id);
+        List<ValidationResponse> response = results.stream()
+                .map(ValidationResultDto::from)
+                .map(dto -> new ValidationResponse(SupportResponse.class.getSimpleName(), dto))
                 .toList();
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/dehold/contentmanager/validation/model/ContentTypeRegistry.java
+++ b/src/main/java/com/dehold/contentmanager/validation/model/ContentTypeRegistry.java
@@ -2,11 +2,13 @@ package com.dehold.contentmanager.validation.model;
 
 import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
+import com.dehold.contentmanager.content.customersupport.model.SupportResponse;
 
 import java.util.Map;
 
 public class ContentTypeRegistry {
     public static final Map<String, Class<? extends Content>> CONTENT_TYPES = Map.of(
-            "blogpost", BlogPost.class
+            "blogpost", BlogPost.class,
+            "supportresponse", SupportResponse.class
     );
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationService.java
@@ -18,4 +18,6 @@ public interface ValidationService {
     List<ValidationResult> runBlogPostValidation(UUID userId);
 
     ValidationReportDto generateValidationReport(UUID userId);
+
+    List<ValidationResult> runSupportResponseValidation(UUID userId);
 }

--- a/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/dehold/contentmanager/validation/service/ValidationServiceImpl.java
@@ -1,7 +1,9 @@
 package com.dehold.contentmanager.validation.service;
 
+import com.dehold.contentmanager.content.Content;
 import com.dehold.contentmanager.content.blogpost.model.BlogPost;
 import com.dehold.contentmanager.content.blogpost.service.BlogPostService;
+import com.dehold.contentmanager.content.customersupport.model.SupportResponse;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipeline;
 import com.dehold.contentmanager.validation.pipeline.ValidationPipelineBuilder;
@@ -16,6 +18,7 @@ import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import com.dehold.contentmanager.content.customersupport.service.SupportResponseService;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -33,10 +36,14 @@ public class ValidationServiceImpl implements ValidationService {
     private final ValidationResultRepository validationResultRepository;
 
     @Autowired
+    private final SupportResponseService supportResponseService;
+
+    @Autowired
     private final BlogPostService blogPostService;
 
     public ValidationServiceImpl(ValidationResultRepository validationResultRepository,
-                                 ValidationPipelineFactory validationPipelineFactory, BlogPostService blogPostService) {
+                                 ValidationPipelineFactory validationPipelineFactory, BlogPostService blogPostService,SupportResponseService supportResponseService) {
+        this.supportResponseService = supportResponseService;
         this.blogPostService = blogPostService;
         this.validationPipelineFactory = validationPipelineFactory;
         this.validationResultRepository = validationResultRepository;
@@ -94,9 +101,9 @@ public class ValidationServiceImpl implements ValidationService {
         return results;
     }
 
-    private void collectResults(BlogPost blogPost, List<ValidationPipeline<BlogPost>> pipelines, List<ValidationResult> results) {
-        for(ValidationPipeline<BlogPost> pipeline : pipelines) {
-            ValidationResult result = pipeline.run(blogPost);
+    private <T extends Content> void collectResults(T content, List<ValidationPipeline<T>> pipelines, List<ValidationResult> results) {
+        for (ValidationPipeline<T> pipeline : pipelines) {
+            ValidationResult result = pipeline.run(content);
             results.add(result);
         }
     }
@@ -127,5 +134,26 @@ public class ValidationServiceImpl implements ValidationService {
     @Override
     public List<ValidationResult> findByUserId(UUID id) {
         return validationResultRepository.findByUserId(id);
+    }
+
+    @Override
+    public List<ValidationResult> runSupportResponseValidation(UUID userId) {
+        List<SupportResponse> responses = supportResponseService.getSupportResponsesByUserId(userId);
+        List<ValidationResult> allResults = new LinkedList<>();
+        for (SupportResponse response : responses) {
+            List<ValidationResult> results = runValidationPipelinesForSupportResponse(userId, response);
+            allResults.addAll(results);
+        }
+        return allResults;
+    }
+
+    private List<ValidationResult> runValidationPipelinesForSupportResponse(UUID userId, SupportResponse response) {
+        List<ValidationPipeline<SupportResponse>> pipelines =
+                validationPipelineFactory.createValidationPipelineForUserAndContentType(userId,
+                        "supportresponse");
+        List<ValidationResult> results = new LinkedList<>();
+        collectResults(response, pipelines, results);
+        persistsResults(results);
+        return results;
     }
 }

--- a/src/main/resources/content-manager-requests/users/users-validateSupportResponses.bru
+++ b/src/main/resources/content-manager-requests/users/users-validateSupportResponses.bru
@@ -1,0 +1,31 @@
+meta {
+  name: users-validateSupportResponses
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/api/users/:userId/validate-supportresponses
+  body: json
+  auth: inherit
+}
+
+params:path {
+  userId: {{USER_ID}}
+}
+
+body:json {
+  {}
+}
+
+assert:status {
+  equals: 200
+}
+
+assert:json {
+  isArray: true
+  length: 1
+  contains: {
+    contentType: "SupportResponse"
+  }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS support_response (
     id UUID PRIMARY KEY,
     user_id UUID,
     text TEXT NOT NULL,
-    support_request UUID NOT NULL,
+    support_request UUID,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS customer_request (
     id UUID PRIMARY KEY,
     user_id UUID,
     text TEXT NOT NULL,
-    support_response UUID NOT NULL,
+    support_response UUID,
     customer_id UUID NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import com.dehold.contentmanager.user.model.User;
 import com.dehold.contentmanager.user.repository.UserRepository;
 import com.dehold.contentmanager.user.web.dto.CreateUserRequest;
 import com.dehold.contentmanager.user.web.dto.UpdateUserRequest;
+import com.dehold.contentmanager.validation.model.ValidationError;
 import com.dehold.contentmanager.validation.model.ValidationPipelineModel;
 import com.dehold.contentmanager.validation.model.ValidationResult;
 import com.dehold.contentmanager.validation.model.ValidationStepType;
@@ -18,7 +19,12 @@ import com.dehold.contentmanager.validation.web.dto.ValidationReportDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationResponse;
 import com.dehold.contentmanager.validation.web.dto.ValidationResultDto;
 import com.dehold.contentmanager.validation.web.dto.ValidationStepDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.dehold.contentmanager.validation.repository.ValidationResultRepository;
+import com.dehold.contentmanager.content.customersupport.model.SupportRequest;
+import com.dehold.contentmanager.content.customersupport.model.SupportResponse;
+import com.dehold.contentmanager.content.customersupport.repository.SupportRequestRepository;
+import com.dehold.contentmanager.content.customersupport.repository.SupportResponseRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,7 +32,12 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 import java.time.Instant;
 import java.util.*;
@@ -50,6 +61,12 @@ class UserControllerIntegrationTest {
 
     @Autowired
     private ValidationResultRepository validationResultRepository;
+
+    @Autowired
+    private SupportRequestRepository supportRequestRepository;
+
+    @Autowired
+    private SupportResponseRepository supportResponseRepository;
 
     @Test
     void createUser_shouldReturnCreatedUser() {
@@ -651,6 +668,275 @@ class UserControllerIntegrationTest {
         assertEquals(1, report.getTotalErrorCount());
         assertEquals("1", report.getErrorCodeToErrorCount().get(LengthValidator.ERROR_CODE));
         assertEquals(1, report.getErrorCodeToErrorCount().size());
+    }
+
+    @Test
+    void givenOneSupportResponseAndPersistedValidationPipeline_validateSupportResponsesForUser_shouldReturnValidationResult() {
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help needed", null, user.getId(), Instant.now(), Instant.now());
+        supportRequestRepository.create(supportRequest);
+
+        SupportResponse supportResponse = new SupportResponse(UUID.randomUUID(), user.getId(), "We have resolved your issue. Thank you.", supportRequest.getId(), Instant.now(), Instant.now());
+        supportResponseRepository.create(supportResponse);
+
+        ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
+        pipelineDto.setUserId(user.getId());
+        pipelineDto.setContentType("supportresponse");
+        pipelineDto.setDescription("Test pipeline for support response validation");
+        pipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "text",
+                Map.of("minLength", "10", "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDto, ValidationPipelineModel.class);
+
+        ResponseEntity<ValidationResponse[]> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses",
+                null, ValidationResponse[].class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        ValidationResponse[] results = response.getBody();
+        assertNotNull(results);
+        assertEquals(1, results.length);
+
+        ValidationResponse validationResponse = results[0];
+        assertEquals("SupportResponse", validationResponse.getContentType());
+
+        ValidationResultDto result = validationResponse.getValidationResult();
+        assertEquals("SupportResponse", result.getContentType());
+        assertEquals(user.getId(), result.getUserId());
+        assertTrue(result.isValid());
+    }
+    
+    @Test
+    void givenInvalidSupportResponseAndPersistedValidationPipeline_validateSupportResponsesForUser_shouldReturnValidationResultWithErrors() {
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help", null, user.getId(), Instant.now(), Instant.now());
+        supportRequestRepository.create(supportRequest);
+
+        SupportResponse supportResponse = new SupportResponse(UUID.randomUUID(), user.getId(), "Hi", supportRequest.getId(), Instant.now(), Instant.now());
+        supportResponseRepository.create(supportResponse);
+
+        ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
+        pipelineDto.setUserId(user.getId());
+        pipelineDto.setContentType("supportresponse");
+        pipelineDto.setDescription("Test pipeline for support response validation");
+        pipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "text",
+                Map.of("minLength", "10", "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDto, ValidationPipelineModel.class);
+
+        ResponseEntity<ValidationResponse[]> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses",
+                null, ValidationResponse[].class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        ValidationResponse[] results = response.getBody();
+        assertNotNull(results);
+        assertEquals(1, results.length);
+
+        ValidationResponse validationResponse = results[0];
+        assertEquals("SupportResponse", validationResponse.getContentType());
+
+        ValidationResultDto result = validationResponse.getValidationResult();
+        assertEquals("SupportResponse", result.getContentType());
+        assertEquals(user.getId(), result.getUserId());
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+
+        assertTrue(result.getErrors().stream().anyMatch(
+                e -> e.code().equals(LengthValidator.ERROR_CODE) &&
+                e.message().equals(LengthValidator.errorMessageTooShort("text"))
+        ));
+    }
+
+    @Test
+    void givenOneSupportResponseAndPipeline_whenValidateSupportResponsesForUser_thenResultPersistedInDatabase() {
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help", null, user.getId(), Instant.now(), Instant.now());
+        supportRequestRepository.create(supportRequest);
+
+        SupportResponse supportResponse = new SupportResponse(UUID.randomUUID(), user.getId(), "Valid response text", supportRequest.getId(), Instant.now(), Instant.now());
+        supportResponseRepository.create(supportResponse);
+
+        ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
+        pipelineDto.setUserId(user.getId());
+        pipelineDto.setContentType("supportresponse");
+        pipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "text",
+                Map.of("minLength", "5", "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDto, ValidationPipelineModel.class);
+
+        restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses", null, ValidationResponse[].class);
+
+        List<ValidationResult> persisted = validationResultRepository.findByUserId(user.getId());
+        assertEquals(1, persisted.size());
+        ValidationResult result = persisted.get(0);
+        assertEquals(user.getId(), result.getUserId());
+        assertEquals(supportResponse.getId(), result.getContentId());
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void givenMultipleSupportResponsesAndPipeline_whenValidateSupportResponsesForUser_thenAllResultsPersistedInDatabase() {
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        SupportRequest request1 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 1", null, user.getId(), Instant.now(), Instant.now());
+        SupportRequest request2 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 2", null, user.getId(), Instant.now(), Instant.now());
+        supportRequestRepository.create(request1);
+        supportRequestRepository.create(request2);
+
+        SupportResponse response1 = new SupportResponse(UUID.randomUUID(), user.getId(), "Valid response", request1.getId(), Instant.now(), Instant.now());
+        SupportResponse response2 = new SupportResponse(UUID.randomUUID(), user.getId(), "Short", request2.getId(), Instant.now(), Instant.now());
+        supportResponseRepository.create(response1);
+        supportResponseRepository.create(response2);
+
+        ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
+        pipelineDto.setUserId(user.getId());
+        pipelineDto.setContentType("supportresponse");
+        pipelineDto.setSteps(List.of(
+                new ValidationStepDto(null, ValidationStepType.LENGTH_VALIDATION, "text",
+                Map.of("minLength", "10", "maxLength", "500"), true)
+        ));
+        restTemplate.postForEntity("http://localhost:" + port + "/api/validation-pipelines", pipelineDto, ValidationPipelineModel.class);
+
+        restTemplate.postForEntity("http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses", null, ValidationResponse[].class);
+
+        List<ValidationResult> persisted = validationResultRepository.findByUserId(user.getId());
+        assertEquals(2, persisted.size());
+
+        Map<UUID, ValidationResult> byContentId = new HashMap<>();
+        for (ValidationResult r : persisted) {
+                byContentId.put(r.getContentId(), r);
+        }
+
+        assertTrue(byContentId.get(response1.getId()).isValid());
+        assertFalse(byContentId.get(response2.getId()).isValid());
+    }
+
+    @Test
+    void givenMultipleSupportResponsesWithViolationsAndPersistedValidationPipeline_validateSupportResponsesForUser_shouldReturnAllValidationResults() throws JsonMappingException, JsonProcessingException {
+        // ---------- Arrange ----------
+        User user = new User(UUID.randomUUID(),
+                "Support User",
+                "support-" + UUID.randomUUID() + "@example.com",
+                Instant.now(), Instant.now());
+        userRepository.createUser(user);
+
+        SupportRequest r1 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 1", null, user.getId(), Instant.now(), Instant.now());
+        SupportRequest r2 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 2", null, user.getId(), Instant.now(), Instant.now());
+        SupportRequest r3 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 3", null, user.getId(), Instant.now(), Instant.now());
+        supportRequestRepository.create(r1);
+        supportRequestRepository.create(r2);
+        supportRequestRepository.create(r3);
+
+        // Valid (30 chars)
+        SupportResponse valid = new SupportResponse(UUID.randomUUID(), user.getId(),
+                "This is a valid response text.", r1.getId(), Instant.now(), Instant.now());
+        // Too short (2 chars)
+        SupportResponse short1 = new SupportResponse(UUID.randomUUID(), user.getId(),
+                "Hi", r2.getId(), Instant.now(), Instant.now());
+        // Too short (1 char)
+        SupportResponse short2 = new SupportResponse(UUID.randomUUID(), user.getId(),
+                "A", r3.getId(), Instant.now(), Instant.now());
+
+        supportResponseRepository.create(valid);
+        supportResponseRepository.create(short1);
+        supportResponseRepository.create(short2);
+
+        // Pipeline – step **id is required**
+        ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
+        pipelineDto.setUserId(user.getId());
+        pipelineDto.setContentType("supportresponse");
+        pipelineDto.setDescription("Min length validation");
+        Map<String, String> lengthParams = new HashMap<>();
+        lengthParams.put("minLength", "10");
+        lengthParams.put("maxLength", "1000"); 
+        pipelineDto.setSteps(List.of(
+                new ValidationStepDto(UUID.randomUUID(),   // ← dummy UUID (required)
+                        ValidationStepType.LENGTH_VALIDATION,
+                        "text",
+                        lengthParams,   // ← only minLength is checked
+                        true)
+        ));
+        
+        // ----------------------------------------------------
+        // FIX 1: Assert pipeline creation status to catch 400s during setup
+        // ----------------------------------------------------
+        ResponseEntity<ValidationPipelineModel> pipelineResponse = restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/validation-pipelines",
+                pipelineDto,
+                ValidationPipelineModel.class);
+                
+        // Assert that the pipeline was created successfully (usually 201 CREATED)
+        assertEquals(HttpStatus.CREATED, pipelineResponse.getStatusCode(), 
+            "Pipeline creation failed during setup. Check server logs for validation errors on pipelineDto."); 
+        // ----------------------------------------------------
+
+        // ---------- Act ----------
+        // Fetch raw JSON response to handle manual deserialization
+        ResponseEntity<String> response = restTemplate.exchange(
+                "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses",
+                HttpMethod.POST,
+                null,
+                String.class
+        );
+    
+        // ---------- Assert ----------
+        // Assert the HTTP status of the final validation call
+        assertEquals(HttpStatus.OK, response.getStatusCode(), 
+            "Validation API call failed. Check server logs for the 400 BAD_REQUEST root cause.");
+            
+        String jsonBody = response.getBody();
+        assertNotNull(jsonBody);
+
+        // ----------------------------------------------------
+        // FIX 2: Manual deserialization using ObjectMapper to resolve Jackson/Record issues
+        // ----------------------------------------------------
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules(); // Helps with Java 8 types like Records and Instant
+
+        // Define the correct type reference for manual deserialization
+        JavaType type = mapper.getTypeFactory().constructCollectionType(List.class, ValidationResponse.class);
+
+        // Manually deserialize the JSON string
+        List<ValidationResponse> results = mapper.readValue(jsonBody, type);
+        // ----------------------------------------------------
+
+        assertNotNull(results);
+        assertEquals(3, results.size());
+    
+        int validCount = 0;
+        int shortCount = 0;
+    
+        for (ValidationResponse vr : results) {
+            ValidationResultDto dto = vr.getValidationResult();
+            assertEquals("SupportResponse", dto.getContentType());
+            assertEquals(user.getId(), dto.getUserId());
+    
+            if (dto.isValid()) {
+                validCount++;
+            } else {
+                assertEquals(1, dto.getErrors().size());
+                ValidationError err = dto.getErrors().get(0);
+                assertEquals(LengthValidator.ERROR_CODE, err.code());
+                assertEquals(LengthValidator.errorMessageTooShort("text"), err.message());
+                shortCount++;
+            }
+        }
+    
+        assertEquals(1, validCount);   // only the first response
+        assertEquals(2, shortCount);   // two short responses
     }
 
 }

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -683,7 +683,7 @@ class UserControllerIntegrationTest  extends ContentManagerApplicationTests {
 
     @Test
     void givenOneSupportResponseAndPersistedValidationPipeline_validateSupportResponsesForUser_shouldReturnValidationResult() {
-        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now(), uniqueUsername(), "TestUser-" + UUID.randomUUID(), true);
         userRepository.createUser(user);
 
         SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help needed", null, user.getId(), Instant.now(), Instant.now());
@@ -723,7 +723,7 @@ class UserControllerIntegrationTest  extends ContentManagerApplicationTests {
 
     @Test
     void givenInvalidSupportResponseAndPersistedValidationPipeline_validateSupportResponsesForUser_shouldReturnValidationResultWithErrors() {
-        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now(), uniqueUsername(), "TestUser-" + UUID.randomUUID(), true);
         userRepository.createUser(user);
 
         SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help", null, user.getId(), Instant.now(), Instant.now());
@@ -769,7 +769,7 @@ class UserControllerIntegrationTest  extends ContentManagerApplicationTests {
 
     @Test
     void givenOneSupportResponseAndPipeline_whenValidateSupportResponsesForUser_thenResultPersistedInDatabase() {
-        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now(), uniqueUsername(), "TestUser-" + UUID.randomUUID(), true);
         userRepository.createUser(user);
 
         SupportRequest supportRequest = new SupportRequest(UUID.randomUUID(), user.getId(), "Help", null, user.getId(), Instant.now(), Instant.now());
@@ -799,7 +799,7 @@ class UserControllerIntegrationTest  extends ContentManagerApplicationTests {
 
     @Test
     void givenMultipleSupportResponsesAndPipeline_whenValidateSupportResponsesForUser_thenAllResultsPersistedInDatabase() {
-        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now());
+        User user = new User(UUID.randomUUID(), "Support User", "support-" + UUID.randomUUID() + "@example.com", Instant.now(), Instant.now(), uniqueUsername(), "TestUser-" + UUID.randomUUID(), true);
         userRepository.createUser(user);
 
         SupportRequest request1 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 1", null, user.getId(), Instant.now(), Instant.now());
@@ -841,7 +841,7 @@ class UserControllerIntegrationTest  extends ContentManagerApplicationTests {
         User user = new User(UUID.randomUUID(),
                 "Support User",
                 "support-" + UUID.randomUUID() + "@example.com",
-                Instant.now(), Instant.now());
+                Instant.now(), Instant.now(), uniqueUsername(), "TestUser-" + UUID.randomUUID(), true);
         userRepository.createUser(user);
 
         SupportRequest r1 = new SupportRequest(UUID.randomUUID(), user.getId(), "Issue 1", null, user.getId(), Instant.now(), Instant.now());

--- a/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/user/web/UserControllerIntegrationTest.java
@@ -840,13 +840,13 @@ class UserControllerIntegrationTest {
         supportRequestRepository.create(r2);
         supportRequestRepository.create(r3);
 
-        // Valid (30 chars)
+        
         SupportResponse valid = new SupportResponse(UUID.randomUUID(), user.getId(),
                 "This is a valid response text.", r1.getId(), Instant.now(), Instant.now());
-        // Too short (2 chars)
+        
         SupportResponse short1 = new SupportResponse(UUID.randomUUID(), user.getId(),
                 "Hi", r2.getId(), Instant.now(), Instant.now());
-        // Too short (1 char)
+        
         SupportResponse short2 = new SupportResponse(UUID.randomUUID(), user.getId(),
                 "A", r3.getId(), Instant.now(), Instant.now());
 
@@ -854,7 +854,6 @@ class UserControllerIntegrationTest {
         supportResponseRepository.create(short1);
         supportResponseRepository.create(short2);
 
-        // Pipeline – step **id is required**
         ValidationPipelineCreateDto pipelineDto = new ValidationPipelineCreateDto();
         pipelineDto.setUserId(user.getId());
         pipelineDto.setContentType("supportresponse");
@@ -870,56 +869,34 @@ class UserControllerIntegrationTest {
                         true)
         ));
         
-        // ----------------------------------------------------
-        // FIX 1: Assert pipeline creation status to catch 400s during setup
-        // ----------------------------------------------------
         ResponseEntity<ValidationPipelineModel> pipelineResponse = restTemplate.postForEntity(
                 "http://localhost:" + port + "/api/validation-pipelines",
                 pipelineDto,
                 ValidationPipelineModel.class);
                 
-        // Assert that the pipeline was created successfully (usually 201 CREATED)
         assertEquals(HttpStatus.CREATED, pipelineResponse.getStatusCode(), 
             "Pipeline creation failed during setup. Check server logs for validation errors on pipelineDto."); 
-        // ----------------------------------------------------
 
-        // ---------- Act ----------
-        // Fetch raw JSON response to handle manual deserialization
-        ResponseEntity<String> response = restTemplate.exchange(
+        ResponseEntity<ValidationResponse[]> response = restTemplate.exchange(
                 "http://localhost:" + port + "/api/users/" + user.getId() + "/validate-supportresponses",
                 HttpMethod.POST,
                 null,
-                String.class
+                ValidationResponse[].class
         );
     
         // ---------- Assert ----------
-        // Assert the HTTP status of the final validation call
         assertEquals(HttpStatus.OK, response.getStatusCode(), 
             "Validation API call failed. Check server logs for the 400 BAD_REQUEST root cause.");
-            
-        String jsonBody = response.getBody();
-        assertNotNull(jsonBody);
 
-        // ----------------------------------------------------
-        // FIX 2: Manual deserialization using ObjectMapper to resolve Jackson/Record issues
-        // ----------------------------------------------------
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.findAndRegisterModules(); // Helps with Java 8 types like Records and Instant
+        ValidationResponse[] body = response.getBody();
+        assertNotNull(body);
 
-        // Define the correct type reference for manual deserialization
-        JavaType type = mapper.getTypeFactory().constructCollectionType(List.class, ValidationResponse.class);
-
-        // Manually deserialize the JSON string
-        List<ValidationResponse> results = mapper.readValue(jsonBody, type);
-        // ----------------------------------------------------
-
-        assertNotNull(results);
-        assertEquals(3, results.size());
+        assertEquals(3, body.length);
     
         int validCount = 0;
         int shortCount = 0;
     
-        for (ValidationResponse vr : results) {
+        for (ValidationResponse vr : body) {
             ValidationResultDto dto = vr.getValidationResult();
             assertEquals("SupportResponse", dto.getContentType());
             assertEquals(user.getId(), dto.getUserId());
@@ -938,5 +915,4 @@ class UserControllerIntegrationTest {
         assertEquals(1, validCount);   // only the first response
         assertEquals(2, shortCount);   // two short responses
     }
-
 }


### PR DESCRIPTION
Closes #67 

Adds bulk validation of **all support responses** for a user via the `users` API, with results persisted in the database. Extends the existing blog post validation flow (see #52).

## Changes
- **New endpoint**: `POST /api/users/{id}/validate-supportresponses`
  - Validates **all** `SupportResponse` entries against user-defined `supportresponse` pipelines
  - Persists results in `validation_result` table
- **Schema fix**: Removed `NOT NULL` from:
  - `customer_request.support_response`
  - `support_response.support_request`
  → Resolves **circular dependency** preventing record creation
- **ValidationService**: Added `runSupportResponseValidation(UUID userId)`

## Result

<img width="957" height="482" alt="Screenshot 2025-11-15 at 1 38 58 AM" src="https://github.com/user-attachments/assets/67d5eb45-46b2-4f9c-8ca1-40b6d0ccf4bc" />

<img width="950" height="732" alt="Screenshot 2025-11-15 at 1 39 34 AM" src="https://github.com/user-attachments/assets/c3b658cf-a841-4b7c-8819-fe115d06cb6c" />

<img width="950" height="606" alt="Screenshot 2025-11-15 at 1 39 59 AM" src="https://github.com/user-attachments/assets/a7498395-2336-4960-b16f-ddfe9437ec35" />


