### PR TITLE
feat: add ProductOffer content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please update for each new feature:
 | 2025-11-13      |denis.h@turing.com | Validation Reports | Added new endpoint `/api/users/:id/validation-report` that provides a summary report of validation results for all content owned by a user. | [#53](https://github.com/Turing-dev-community/content-manager/issues/57) |
 | 2025-11-14      |denis.h@turing.com | Introduce a Generic Content Model | More flexible content creation by providing a generic content model that allows custom content types and fields | [#61](https://github.com/Turing-dev-community/content-manager/issues/61) |
 | 2025-11-14      | riddhi.s@turing.com    | Add pagination to GET /api/blogposts               | Add `page` and `size` query params to blog post list endpoint. Return paginated response with metadata.                       | [#55](https://github.com/Turing-dev-community/content-manager/issues/55) |
+| 2025-11-17 | riddhi.s@turing.com | Add ProductOffer content type | New marketplace-ready content type with pricing, stock, delivery fields. Model + repository + schema. No API yet. | [#74](https://github.com/Turing-dev-community/content-manager/issues/74) |
 
 ### Overview
 - **Content Management**: Create, read, update, and delete various content types

--- a/src/main/java/com/dehold/contentmanager/content/productoffer/model/ProductOffer.java
+++ b/src/main/java/com/dehold/contentmanager/content/productoffer/model/ProductOffer.java
@@ -1,0 +1,97 @@
+package com.dehold.contentmanager.content.productoffer.model;
+
+import com.dehold.contentmanager.content.Content;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public class ProductOffer implements Content {
+
+    private UUID id;
+    private UUID userId;
+
+    private String title;
+    private String description;
+    private String brand;
+    private String category;
+
+    private BigDecimal originalPrice;
+    private BigDecimal offerPrice;
+    private Integer discountPercentage;
+
+    private Integer stockQuantity;
+    private String deliveryTime;
+    private boolean isActive = true;
+
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    // === Constructors ===
+    public ProductOffer() {}
+
+    public ProductOffer(UUID id, UUID userId, String title, String description, String brand,
+                        String category, BigDecimal originalPrice, BigDecimal offerPrice,
+                        Integer discountPercentage, Integer stockQuantity, String deliveryTime,
+                        boolean isActive, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.title = title;
+        this.description = description;
+        this.brand = brand;
+        this.category = category;
+        this.originalPrice = originalPrice;
+        this.offerPrice = offerPrice;
+        this.discountPercentage = discountPercentage;
+        this.stockQuantity = stockQuantity;
+        this.deliveryTime = deliveryTime;
+        this.isActive = isActive;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // === Getters & Setters ===
+    @Override
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    @Override
+    public UUID getUserId() { return userId; }
+    public void setUserId(UUID userId) { this.userId = userId; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getBrand() { return brand; }
+    public void setBrand(String brand) { this.brand = brand; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+
+    public BigDecimal getOriginalPrice() { return originalPrice; }
+    public void setOriginalPrice(BigDecimal originalPrice) { this.originalPrice = originalPrice; }
+
+    public BigDecimal getOfferPrice() { return offerPrice; }
+    public void setOfferPrice(BigDecimal offerPrice) { this.offerPrice = offerPrice; }
+
+    public Integer getDiscountPercentage() { return discountPercentage; }
+    public void setDiscountPercentage(Integer discountPercentage) { this.discountPercentage = discountPercentage; }
+
+    public Integer getStockQuantity() { return stockQuantity; }
+    public void setStockQuantity(Integer stockQuantity) { this.stockQuantity = stockQuantity; }
+
+    public String getDeliveryTime() { return deliveryTime; }
+    public void setDeliveryTime(String deliveryTime) { this.deliveryTime = deliveryTime; }
+
+    public boolean isActive() { return isActive; }
+    public void setActive(boolean active) { isActive = active; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepository.java
+++ b/src/main/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepository.java
@@ -1,0 +1,126 @@
+package com.dehold.contentmanager.content.productoffer.repository;
+
+import com.dehold.contentmanager.content.productoffer.model.ProductOffer;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public class ProductOfferRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ProductOfferRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private static final RowMapper<ProductOffer> ROW_MAPPER = new ProductOfferRowMapper();
+
+    private static class ProductOfferRowMapper implements RowMapper<ProductOffer> {
+        @Override
+        public ProductOffer mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ProductOffer(
+                UUID.fromString(rs.getString("id")),
+                UUID.fromString(rs.getString("user_id")),
+                rs.getString("title"),
+                rs.getString("description"),
+                rs.getString("brand"),
+                rs.getString("category"),
+                rs.getObject("original_price", BigDecimal.class),
+                rs.getObject("offer_price", BigDecimal.class),
+                getInteger(rs, "discount_percentage"),
+                getInteger(rs, "stock_quantity"),
+                rs.getString("delivery_time"),
+                rs.getBoolean("is_active"),
+                rs.getTimestamp("created_at").toInstant(),
+                rs.getTimestamp("updated_at").toInstant()
+            );
+        }
+
+        private Integer getInteger(ResultSet rs, String column) throws SQLException {
+            Object obj = rs.getObject(column);
+            return obj == null ? null : ((Number) obj).intValue();
+        }
+    }
+
+    // === CREATE ===
+    public void create(ProductOffer offer) {
+        String sql = """
+            INSERT INTO product_offer (
+                id, user_id, title, description, brand, category,
+                original_price, offer_price, discount_percentage,
+                stock_quantity, delivery_time, is_active,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+        jdbcTemplate.update(sql,
+            offer.getId(),
+            offer.getUserId(),
+            offer.getTitle(),
+            offer.getDescription(),
+            offer.getBrand(),
+            offer.getCategory(),
+            offer.getOriginalPrice(),
+            offer.getOfferPrice(),
+            offer.getDiscountPercentage(),
+            offer.getStockQuantity(),
+            offer.getDeliveryTime(),
+            offer.isActive(),
+            Timestamp.from(offer.getCreatedAt()),
+            Timestamp.from(offer.getUpdatedAt())
+        );
+    }
+
+    // === READ ALL BY USER ===
+    public List<ProductOffer> findByUserId(UUID userId) {
+        String sql = "SELECT * FROM product_offer WHERE user_id = ? ORDER BY created_at DESC";
+        return jdbcTemplate.query(sql, ROW_MAPPER, userId);
+    }
+
+    // === READ ONE ===
+    public ProductOffer findById(UUID id) {
+        String sql = "SELECT * FROM product_offer WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, id);
+    }
+
+    // === UPDATE ===
+    public void update(ProductOffer offer) {
+        String sql = """
+            UPDATE product_offer SET
+                title = ?, description = ?, brand = ?, category = ?,
+                original_price = ?, offer_price = ?, discount_percentage = ?,
+                stock_quantity = ?, delivery_time = ?, is_active = ?,
+                updated_at = ?
+            WHERE id = ?
+            """;
+
+        jdbcTemplate.update(sql,
+            offer.getTitle(),
+            offer.getDescription(),
+            offer.getBrand(),
+            offer.getCategory(),
+            offer.getOriginalPrice(),
+            offer.getOfferPrice(),
+            offer.getDiscountPercentage(),
+            offer.getStockQuantity(),
+            offer.getDeliveryTime(),
+            offer.isActive(),
+            Timestamp.from(Instant.now()),
+            offer.getId()
+        );
+    }
+
+    // === DELETE ===
+    public void delete(UUID id) {
+        jdbcTemplate.update("DELETE FROM product_offer WHERE id = ?", id);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -94,3 +94,23 @@ CREATE TABLE blog_post_history (
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );
+
+-- Product Offer Table
+CREATE TABLE IF NOT EXISTS product_offer (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    brand VARCHAR(255),
+    category VARCHAR(255),
+    original_price DECIMAL(12,2),
+    offer_price DECIMAL(12,2) NOT NULL,
+    discount_percentage INTEGER,
+    stock_quantity INTEGER,
+    delivery_time VARCHAR(100),
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_product_offer_user FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE
+);

--- a/src/test/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepositoryIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepositoryIntegrationTest.java
@@ -24,16 +24,51 @@ class ProductOfferRepositoryIntegrationTest {
     private UserRepository userRepository;
 
     @Test
-    void shouldCreateAndRetrieveSingleOffer() {
-        User user = createUniqueUser("single-offer@example.com");
-        ProductOffer offer = createSampleOffer(user.getId());
+    void shouldCreateAndRetrieveSingleOffer_verifyAllFields() {
+        // Arrange
+        User user = createUniqueUser("all-fields-test@example.com");
 
+        ProductOffer offer = new ProductOffer(
+            UUID.randomUUID(),
+            user.getId(),
+            "MacBook Pro M4",
+            "14-inch, 16GB RAM, 512GB SSD",
+            "Apple",
+            "Laptops",
+            new BigDecimal("199900.00"),
+            new BigDecimal("179900.00"),
+            10,
+            25,
+            "Free delivery in 1 day",
+            true,
+            Instant.now(),
+            Instant.now()
+        );
+
+        // Act
         productOfferRepository.create(offer);
-
         List<ProductOffer> result = productOfferRepository.findByUserId(user.getId());
-        assertEquals(1, result.size());
-        assertEquals("iPhone 15 Pro", result.get(0).getTitle());
-        assertEquals(new BigDecimal("119900.00"), result.get(0).getOfferPrice());
+        ProductOffer retrieved = result.get(0);
+
+        // Assert — ALL FIELDS EXPLICITLY VERIFIED
+        assertNotNull(retrieved.getId());
+        assertEquals(user.getId(), retrieved.getUserId());
+
+        assertEquals("MacBook Pro M4", retrieved.getTitle());
+        assertEquals("14-inch, 16GB RAM, 512GB SSD", retrieved.getDescription());
+        assertEquals("Apple", retrieved.getBrand());
+        assertEquals("Laptops", retrieved.getCategory());
+
+        assertEquals(new BigDecimal("199900.00"), retrieved.getOriginalPrice());
+        assertEquals(new BigDecimal("179900.00"), retrieved.getOfferPrice());
+        assertEquals(Integer.valueOf(10), retrieved.getDiscountPercentage());
+
+        assertEquals(Integer.valueOf(25), retrieved.getStockQuantity());
+        assertEquals("Free delivery in 1 day", retrieved.getDeliveryTime());
+        assertTrue(retrieved.isActive());
+
+        assertNotNull(retrieved.getCreatedAt());
+        assertNotNull(retrieved.getUpdatedAt());
     }
 
     @Test
@@ -47,19 +82,29 @@ class ProductOfferRepositoryIntegrationTest {
     }
 
     @Test
-    void shouldUpdateOffer() {
-        User user = createUniqueUser("update-offer@example.com");
+    void shouldUpdateOffer_verifyMutableFields() {
+        User user = createUniqueUser("update-test@example.com");
         ProductOffer offer = createSampleOffer(user.getId());
+
         productOfferRepository.create(offer);
 
-        offer.setOfferPrice(new BigDecimal("109900.00"));
-        offer.setStockQuantity(10);
+        // Update key fields
+        offer.setTitle("Updated Title");
+        offer.setOfferPrice(new BigDecimal("99900.00"));
+        offer.setDiscountPercentage(25);
+        offer.setStockQuantity(5);
+        offer.setDeliveryTime("Next week");
         offer.setActive(false);
+
         productOfferRepository.update(offer);
 
         ProductOffer updated = productOfferRepository.findById(offer.getId());
-        assertEquals(new BigDecimal("109900.00"), updated.getOfferPrice());
-        assertEquals(10, updated.getStockQuantity());
+
+        assertEquals("Updated Title", updated.getTitle());
+        assertEquals(new BigDecimal("99900.00"), updated.getOfferPrice());
+        assertEquals(Integer.valueOf(25), updated.getDiscountPercentage());
+        assertEquals(Integer.valueOf(5), updated.getStockQuantity());
+        assertEquals("Next week", updated.getDeliveryTime());
         assertFalse(updated.isActive());
     }
 

--- a/src/test/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepositoryIntegrationTest.java
+++ b/src/test/java/com/dehold/contentmanager/content/productoffer/repository/ProductOfferRepositoryIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.dehold.contentmanager.content.productoffer.repository;
+
+import com.dehold.contentmanager.content.productoffer.model.ProductOffer;
+import com.dehold.contentmanager.user.model.User;
+import com.dehold.contentmanager.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ProductOfferRepositoryIntegrationTest {
+
+    @Autowired
+    private ProductOfferRepository productOfferRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void shouldCreateAndRetrieveSingleOffer() {
+        User user = createUniqueUser("single-offer@example.com");
+        ProductOffer offer = createSampleOffer(user.getId());
+
+        productOfferRepository.create(offer);
+
+        List<ProductOffer> result = productOfferRepository.findByUserId(user.getId());
+        assertEquals(1, result.size());
+        assertEquals("iPhone 15 Pro", result.get(0).getTitle());
+        assertEquals(new BigDecimal("119900.00"), result.get(0).getOfferPrice());
+    }
+
+    @Test
+    void shouldRetrieveMultipleOffersForUser() {
+        User user = createUniqueUser("multiple-offers@example.com");
+        productOfferRepository.create(createSampleOffer(user.getId()));
+        productOfferRepository.create(createSampleOffer(user.getId(), "Pixel 9", new BigDecimal("89900.00")));
+
+        List<ProductOffer> offers = productOfferRepository.findByUserId(user.getId());
+        assertEquals(2, offers.size());
+    }
+
+    @Test
+    void shouldUpdateOffer() {
+        User user = createUniqueUser("update-offer@example.com");
+        ProductOffer offer = createSampleOffer(user.getId());
+        productOfferRepository.create(offer);
+
+        offer.setOfferPrice(new BigDecimal("109900.00"));
+        offer.setStockQuantity(10);
+        offer.setActive(false);
+        productOfferRepository.update(offer);
+
+        ProductOffer updated = productOfferRepository.findById(offer.getId());
+        assertEquals(new BigDecimal("109900.00"), updated.getOfferPrice());
+        assertEquals(10, updated.getStockQuantity());
+        assertFalse(updated.isActive());
+    }
+
+    @Test
+    void shouldDeleteOffer() {
+        User user = createUniqueUser("delete-offer@example.com");
+        ProductOffer offer = createSampleOffer(user.getId());
+        productOfferRepository.create(offer);
+
+        productOfferRepository.delete(offer.getId());
+        List<ProductOffer> result = productOfferRepository.findByUserId(user.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyListForNoOffers() {
+        User user = createUniqueUser("no-offers@example.com");
+        List<ProductOffer> offers = productOfferRepository.findByUserId(user.getId());
+        assertTrue(offers.isEmpty());
+    }
+
+    // === Helper Methods ===
+    private User createUniqueUser(String email) {
+        User user = new User(UUID.randomUUID(), "offeruser", email, Instant.now(), Instant.now());
+        userRepository.createUser(user);
+        return user;
+    }
+
+    private ProductOffer createSampleOffer(UUID userId) {
+        return createSampleOffer(userId, "iPhone 15 Pro", new BigDecimal("119900.00"));
+    }
+
+    private ProductOffer createSampleOffer(UUID userId, String title, BigDecimal offerPrice) {
+        return new ProductOffer(
+            UUID.randomUUID(), userId, title, "Latest flagship", "Apple", "Smartphones",
+            new BigDecimal("129900.00"), offerPrice, 8, 50, "2-3 days", true,
+            Instant.now(), Instant.now()
+        );
+    }
+}


### PR DESCRIPTION
Closes #74 

## Summary
Introduces a new content type `ProductOffer` to represent marketplace product listings (e.g., Amazon-style offers).

## Changes
- New plain model: `ProductOffer` with realistic marketplace fields
- Implements `Content` interface
- `ProductOfferRepository` with full manual CRUD (JdbcTemplate)
- H2 schema update (`schema.sql`)
- 5 integration tests (create, read, update, delete, empty)
- Updated README feature table

**No API endpoints yet** — only model + persistence (as requested).